### PR TITLE
Better make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,18 @@ test_source_target:
 
 test: test_dump test_cron test_source_target	
 
-clean-test:
-	docker kill $(docker ps | awk '/mysql/ {print $1}')
-	docker rm $(docker ps -a | awk '/mysql/ {print $1}')
-	docker kill s3 && docker rm s3
-	docker network rm mysqltest
+.PHONY: clean-test-stop clean-test-remove clean-test
+clean-test-stop:
+	$(eval IDS:=$(strip $(shell docker ps --filter label=mysqltest -q)))
+	@if [ -n "$(IDS)" ]; then docker kill $(IDS); fi
+
+clean-test-remove:
+	$(eval IDS:=$(shell docker ps -a --filter label=mysqltest -q))
+	@if [ -n "$(IDS)" ]; then docker rm $(IDS); fi
+
+clean-test-network:
+	$(eval IDS:=$(shell docker network ls --filter label=mysqltest -q))
+	@if [ -n "$(IDS)" ]; then docker network rm $(IDS); fi
+
+clean-test: clean-test-stop clean-test-remove clean-test-network
 

--- a/test/test_dump.sh
+++ b/test/test_dump.sh
@@ -87,7 +87,7 @@ function runtest() {
 	# change our target
         # ensure that we remove leading whitespace from targets
         allTargets=$(echo $allTargets | awk '{$1=$1;print}')
-  cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET="${allTargets}" -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v ${TMPBACKUPDIR}/${sequence}/:/scripts.d/ -v ${TMPBACKUPDIR}:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
+  cid=$(docker run --label mysqltest --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET="${allTargets}" -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v ${TMPBACKUPDIR}/${sequence}/:/scripts.d/ -v ${TMPBACKUPDIR}:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
 	echo $cid
 }
 
@@ -234,13 +234,13 @@ docker build $QUIET -t ${SMB_IMAGE} -f ./Dockerfile_smb .
 
 # create the network we need
 [[ "$DEBUG" != "0" ]] && echo "Creating the test network"
-docker network create mysqltest
+docker network create mysqltest --label mysqltest
 
 # run the test images we need
 [[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
-smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v ${TMPBACKUPDIR}:/share/backups -t ${SMB_IMAGE})
-mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
-s3_cid=$(docker run --net mysqltest --name s3 -d -v ${TMPBACKUPDIR}:/fakes3_root/s3/mybucket lphoward/fake-s3 -r /fakes3_root -p 443)
+smb_cid=$(docker run --label mysqltest --net mysqltest --name=smb  -d -p 445:445 -v ${TMPBACKUPDIR}:/share/backups -t ${SMB_IMAGE})
+mysql_cid=$(docker run --label mysqltest --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
+s3_cid=$(docker run --label mysqltest --net mysqltest --name s3 -d -v ${TMPBACKUPDIR}:/fakes3_root/s3/mybucket lphoward/fake-s3 -r /fakes3_root -p 443)
 
 
 # Allow up to 20 seconds for the database to be ready

--- a/test/test_source_target.sh
+++ b/test/test_source_target.sh
@@ -45,7 +45,7 @@ function run_default_source_target_test() {
 	fi
 
     # change our target
-    cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v ${BACKUP_DIRECTORY_BASE}/${seqno}/:/scripts.d/ -v ${BACKUP_DIRECTORY_BASE}:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
+    cid=$(docker run --label mysqltest --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v ${BACKUP_DIRECTORY_BASE}/${seqno}/:/scripts.d/ -v ${BACKUP_DIRECTORY_BASE}:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
 	echo $cid
 }
 
@@ -130,13 +130,13 @@ docker build $QUIET -t ${SMB_IMAGE} -f ./Dockerfile_smb .
 
 # create the network we need
 [[ "$DEBUG" != "0" ]] && echo "Creating the test network"
-docker network create mysqltest
+docker network create mysqltest --label mysqltest
 
 # run the test images we need
 [[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
-smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v ${BACKUP_DIRECTORY_BASE}:/share/backups:z -t ${SMB_IMAGE})
-mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source:z -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
-s3_cid=$(docker run --net mysqltest --name s3 -d -v ${BACKUP_DIRECTORY_BASE}:/fakes3_root/s3/mybucket:z lphoward/fake-s3 -r /fakes3_root -p 443)
+smb_cid=$(docker run --label mysqltest --net mysqltest --name=smb  -d -p 445:445 -v ${BACKUP_DIRECTORY_BASE}:/share/backups:z -t ${SMB_IMAGE})
+mysql_cid=$(docker run --label mysqltest --net mysqltest --name mysql -d -v /tmp/source:/tmp/source:z -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
+s3_cid=$(docker run --label mysqltest --net mysqltest --name s3 -d -v ${BACKUP_DIRECTORY_BASE}:/fakes3_root/s3/mybucket:z lphoward/fake-s3 -r /fakes3_root -p 443)
 
 # Allow up to 20 seconds for the database to be ready
 db_connect="docker exec -i $mysql_cid mysql -u$MYSQLUSER -p$MYSQLPW --wait --connect_timeout=20 tester"


### PR DESCRIPTION
Adds labels to all containers and networks created during tests, and uses those labels to remove them in `clean-test` target in Makefile.

Also cleans up conditional Makefile logic for `clean-test`