### PR TITLE
Add tagged releases and clean up actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: build
       run: make build
     - name: test
@@ -30,4 +30,13 @@ jobs:
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: deploy   # when merged into master, tag master and push - ideally, this would be a separate job, but you cannot share docker build cache between jobs
       if: github.event_name == 'push' && endsWith(github.ref,'/master')
-      run: make push
+      run: |
+        make push                 # push based on the default, which is the hash tag
+        make push TAG=latest # push latest for master
+    - name: set tag env
+      id: get_tag
+      if: github.event_name == 'create' && startsWith(github.ref,'refs/tags/')
+      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+    - name: release  # when based on a tag, tag the specific commit and push
+      if: github.event_name == 'create' && startsWith(github.ref,'refs/tags/')
+      run: make push TAG=${{ steps.get_tag.outputs.tag }} # push a tagged image

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 
 TAG ?= $(shell git log -n 1 --pretty=format:"%H")
 IMAGE ?= databack/mysql-backup
+BUILDIMAGE ?= $(IMAGE):build
 TARGET ?= $(IMAGE):$(TAG)
 
 
 build:
-	docker build -t $(TARGET) .
+	docker build -t $(BUILDIMAGE) .
 
 push: build
-	docker tag $(TARGET) $(IMAGE):latest
+	docker tag $(BUILDIMAGE) $(TARGET)
 	docker push $(TARGET)
-	docker push $(IMAGE):latest
 
 test_dump:
 	cd test && DEBUG=$(DEBUG) ./test_dump.sh
@@ -23,7 +23,7 @@ test_cron:
 test_source_target:
 	cd test && ./test_source_target.sh
 
-test: test_dump test_cron test_source_target	
+test: test_dump test_cron test_source_target
 
 .PHONY: clean-test-stop clean-test-remove clean-test
 clean-test-stop:
@@ -49,4 +49,3 @@ clean-test-network:
 	@echo
 
 clean-test: clean-test-stop clean-test-remove clean-test-network
-


### PR DESCRIPTION
Several things:

* Clean up Makefile so that the build is always `databack/mysql-backup:build`, and tags and pushes out images based on the passed `TAG` var to Makefile, or default to the git hash
* Add support for pushing out tagged images