### PR TITLE
Add aws cli s3 param

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `AWS_SECRET_ACCESS_KEY`: AWS Secret Access Key
 * `AWS_DEFAULT_REGION`: Region in which the bucket resides
 * `AWS_ENDPOINT_URL`: Specify an alternative endpoint for s3 interopable systems e.g. Digitalocean
-* `AWS_CLI_OPTS`: Specify additional options for the `aws s3` command, primarily those from [here](https://docs.aws.amazon.com/cli/latest/reference/#options). _Be careful_, as you can break something!
+* `AWS_CLI_OPTS`: Additional arguments to be passed to the `aws` part of the `aws s3 cp` command, click [here](https://docs.aws.amazon.com/cli/latest/reference/#options) for a list. _Be careful_, as you can break something!
+* `AWS_CLI_S3_CP_OPTS`: Additional arguments to be passed to the `s3 cp` part of the `aws s3 cp` command, click [here](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html#options) for a list. If you are using AWS KMS, `sse`, `sse-kms-key-id`, etc., may be of interest.
 * `SMB_USER`: SMB username. May also be specified in `DB_DUMP_TARGET` with an `smb://` url. If both specified, this variable overrides the value in the URL.
 * `SMB_PASS`: SMB password. May also be specified in `DB_DUMP_TARGET` with an `smb://` url. If both specified, this variable overrides the value in the URL.
 * `COMPRESSION`: Compression to use. Supported are: `gzip` (default), `bzip2`

--- a/entrypoint
+++ b/entrypoint
@@ -26,6 +26,7 @@ file_env "DB_RESTORE_TARGET"
 file_env "AWS_ENDPOINT_URL"
 file_env "AWS_ENDPOINT_OPT"
 file_env "AWS_CLI_OPTS"
+file_env "AWS_CLI_S3_CP_OPTS"
 file_env "AWS_ACCESS_KEY_ID"
 file_env "AWS_SECRET_ACCESS_KEY"
 file_env "AWS_DEFAULT_REGION"
@@ -111,7 +112,7 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
     cp $DB_RESTORE_TARGET $TMPRESTORE 2>/dev/null
   elif [[ "${uri[schema]}" == "s3" ]]; then
     [[ -n "$AWS_ENDPOINT_URL" ]] && AWS_ENDPOINT_OPT="--endpoint-url $AWS_ENDPOINT_URL"
-      aws ${AWS_CLI_OPTS} ${AWS_ENDPOINT_OPT} s3 cp "${DB_RESTORE_TARGET}" $TMPRESTORE
+      aws ${AWS_CLI_OPTS} ${AWS_ENDPOINT_OPT} s3 cp ${AWS_CLI_S3_CP_OPTS} "${DB_RESTORE_TARGET}" $TMPRESTORE
   elif [[ "${uri[schema]}" == "smb" ]]; then
     if [[ -n "$SMB_USER" ]]; then
       UPASSARG="-U"


### PR DESCRIPTION
This adds a new environment variable: `AWS_CLI_S3_CP_OPTS`.

Due to project requirements we required a KMS key per tenant in a shared bucket (in which each tenant has its own object prefix). Since this cannot be achieved using a default configuration in the bucket itself, we added a new variable to this project allowing additional options to be passed to the `cp` subcommand of the AWS CLI.