### PR TITLE
Added option DB_NAMES_EXCLUDE to prevent specific databases from beeing dumped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Avi Deitcher <https://github.com/deitch>
 
 # install the necessary client
 # the mysql-client must be 10.3.15 or later
-RUN apk add --update 'mariadb-client>10.3.15' mariadb-connector-c bash python3 samba-client shadow openssl && \
+RUN apk add --update 'mariadb-client>10.3.15' mariadb-connector-c bash python3 samba-client shadow openssl tzdata && \
     rm -rf /var/cache/apk/* && \
     touch /etc/samba/smb.conf && \
     pip3 install awscli

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following are the environment variables for a backup:
 
 __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables-e-env-env-file), [docker secrets](https://docs.docker.com/engine/swarm/secrets/) to keep your secrets out of your shell history__
 
+* `TZ`: set the timezone used for backup timestamps, for example `TZ=Europe/Vienna`, defaults to `UTC`
 * `DB_SERVER`: hostname to connect to database. Required.
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
-* `DB_NAMES`: names of databases to dump; defaults to all databases in the database server
+* `DB_NAMES`: names of databases to dump (seperated by space); defaults to all databases in the database server
+* `DB_NAMES_EXCLUDE`: names of databases (seperated by space) to exclude from the dump; `information_schema` and `performance_schema` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` theese two will not be dumped by mysqldump.
 * `DB_DUMP_FREQ`: How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 * `DB_DUMP_BEGIN`: What time to do the first dump. Defaults to immediate. Must be in one of two formats:
     * Absolute: HHMM, e.g. `2330` or `0415`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
 * `DB_NAMES`: names of databases to dump (seperated by space); defaults to all databases in the database server
-* `DB_NAMES_EXCLUDE`: names of databases (seperated by space) to exclude from the dump; `information_schema` and `performance_schema` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` theese two will not be dumped by mysqldump.
+* `DB_NAMES_EXCLUDE`: names of databases (seperated by space) to exclude from the dump; `information_schema` and `performance_schema` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then theese two databases will not be dumped by mysqldump.
 * `DB_DUMP_FREQ`: How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 * `DB_DUMP_BEGIN`: What time to do the first dump. Defaults to immediate. Must be in one of two formats:
     * Absolute: HHMM, e.g. `2330` or `0415`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `COMPRESSION`: Compression to use. Supported are: `gzip` (default), `bzip2`
 * `DB_DUMP_BY_SCHEMA`: Whether to use separate files per schema in the compressed file (`true`), or a single dump file (`false`). Defaults to `false`.
 * `DB_DUMP_KEEP_PERMISSIONS`: Whether to keep permissions for a file target. By default, `mysql-backup` copies the backup compressed file to the target with `cp -a`. In certain filesystems with certain permissions, this may cause errors. You can disable the `-a` flag by setting `DB_DUMP_KEEP_PERMISSIONS=false`. Defaults to `true`.
-* `MYSQLDUMP_OPTS`: A string of options to pass to `mysqldump`, e.g. `MYSQLDUMP_OPTS="--opt abc --param def --max_allowed_packet=123455678"` will run `mysqldump --opt abc --param def --max_allowed_packet=123455678`
+* `MYSQLDUMP_OPTS`: A string of options to pass to `mysqldump`, e.g. `MYSQLDUMP_OPTS=--opt abc --param def --max_allowed_packet=123455678` will run `mysqldump --opt abc --param def --max_allowed_packet=123455678`
 
 ### Scheduling
 There are several options for scheduling how often a backup should run:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
 * `DB_NAMES`: names of databases to dump (seperated by space); defaults to all databases in the database server
-* `DB_NAMES_EXCLUDE`: names of databases (seperated by space) to exclude from the dump; `information_schema` and `performance_schema` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then theese two databases will not be dumped by mysqldump.
+* `DB_NAMES_EXCLUDE`: names of databases (seperated by space) to exclude from the dump; `information_schema`. `performance_schema`, `sys` and `mysql` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then theese two databases will not be dumped by mysqldump.
 * `DB_DUMP_FREQ`: How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 * `DB_DUMP_BEGIN`: What time to do the first dump. Defaults to immediate. Must be in one of two formats:
     * Absolute: HHMM, e.g. `2330` or `0415`

--- a/entrypoint
+++ b/entrypoint
@@ -8,11 +8,13 @@ fi
 
 # get all variables from environment variables or files (e.g. VARIABLE_NAME_FILE)
 # (setting defaults happens here, too)
+file_env "TZ"
 file_env "DB_SERVER"
 file_env "DB_PORT"
 file_env "DB_USER"
 file_env "DB_PASS"
 file_env "DB_NAMES"
+file_env "DB_NAMES_EXCLUDE"
 
 file_env "DB_DUMP_FREQ" "1440"
 file_env "DB_DUMP_BEGIN" "+0"

--- a/functions.sh
+++ b/functions.sh
@@ -124,7 +124,7 @@ function do_dump() {
       DB_NAMES_EXCLUDE=(`echo $DB_NAMES_EXCLUDE`)
     else
       # if not -> exclude the default ones
-      DB_NAMES_EXCLUDE=(information_schema performance_schema)
+      DB_NAMES_EXCLUDE=(information_schema performance_schema mysql sys)
     fi
     for onedb in $DB_NAMES; do
       if [[ " ${DB_NAMES_EXCLUDE[@]} " =~ " ${onedb} " ]]; then

--- a/functions.sh
+++ b/functions.sh
@@ -119,7 +119,18 @@ function do_dump() {
       DB_NAMES=$(mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS -N -e 'show databases')
       [ $? -ne 0 ] && return 1
     fi
+    if [[ -n "$DB_NAMES_EXCLUDE" ]]; then
+      # exclude databases if specificied
+      DB_NAMES_EXCLUDE=(`echo $DB_NAMES_EXCLUDE`)
+    else
+      # if not -> exclude the default ones
+      DB_NAMES_EXCLUDE=(information_schema performance_schema)
+    fi
     for onedb in $DB_NAMES; do
+      if [[ " ${DB_NAMES_EXCLUDE[@]} " =~ " ${onedb} " ]]; then
+      	# skip database if on exclude list
+        continue
+      fi
       mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${onedb} $MYSQLDUMP_OPTS > $workdir/${onedb}_${now}.sql
       [ $? -ne 0 ] && return 1
     done

--- a/functions.sh
+++ b/functions.sh
@@ -91,7 +91,7 @@ function uri_parser() {
 #
 function do_dump() {
   # what is the name of our source and target?
-  now=$(date -u +"%Y%m%d%H%M%S")
+  now=$(date +"%Y%m%d%H%M%S")
   # SOURCE: file that the uploader looks for when performing the upload
   # TARGET: the remote file that is actually uploaded
   SOURCE=db_backup_${now}.$EXTENSION


### PR DESCRIPTION
See #138 

With the new environment variable `DB_NAMES_EXCLUDE` one can specifiy a space seperated list of database names to exclude from mysqldump.

New default: By default the databases`information_schema`, `mysql`, `sys`and `performance_schema` are excluded to prevent errors when dumping all databases.

This only applies to the dump-by-schema mode (`DB_DUMP_BY_SCHEMA=true`) otherwise `mysqldump --all-databases` is used which excludes theese database by default

> mysqldump does not dump the performance_schema or sys schema by default. To dump any of these, name them explicitly on the command line. You can also name them with the --databases option. For performance_schema, also use the --skip-lock-tables option.

> In MySQL 8.0, the mysql schema is considered a system schema that cannot be dropped by end users.

Taken from: https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html