### PR TITLE
Automatically Removes backups that are over X days old

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
     * SMB: If the value of `DB_DUMP_TARGET` is a URL of the format `smb://hostname/share/path/` then it will connect via SMB.
     * S3: If the value of `DB_DUMP_TARGET` is a URL of the format `s3://bucketname/path` then it will connect via awscli.
 * `DB_DUMP_SAFECHARS`: The dump filename usually includes the character `:` in the date, to comply with RFC3339. Some systems and shells don't like that character. If this environment variable is set, it will replace all `:` with `-`.
+* `DB_DUMP_ARCHIVE_DAYS_TO_KEEP`: Number of days to keep backups
 * `AWS_ACCESS_KEY_ID`: AWS Key ID
 * `AWS_SECRET_ACCESS_KEY`: AWS Secret Access Key
 * `AWS_DEFAULT_REGION`: Region in which the bucket resides

--- a/entrypoint
+++ b/entrypoint
@@ -223,6 +223,7 @@ else
       # Calculate the wait time
       waittime=$(($target_time - $current_time))
     fi
+	#Deletes backup files that are over X days old. 
     if [[ -n "$DB_DUMP_ARCHIVE_DAYS_TO_KEEP" ]]; then
       echo Removing Archives older than $DB_DUMP_ARCHIVE_DAYS_TO_KEEP days
       find $DB_DUMP_TARGET -mtime +$DB_DUMP_ARCHIVE_DAYS_TO_KEEP -exec rm {} \;

--- a/entrypoint
+++ b/entrypoint
@@ -224,10 +224,7 @@ else
       waittime=$(($target_time - $current_time))
     fi
 	#Deletes backup files that are over X days old. 
-    if [[ -n "$DB_DUMP_ARCHIVE_DAYS_TO_KEEP" ]]; then
-      echo Removing Archives older than $DB_DUMP_ARCHIVE_DAYS_TO_KEEP days
-      find $DB_DUMP_TARGET -mtime +$DB_DUMP_ARCHIVE_DAYS_TO_KEEP -exec rm {} \;
-    fi
+    delete_old_backups
     sleep $waittime
     last_run=$(date +"%s")
   done

--- a/entrypoint
+++ b/entrypoint
@@ -20,6 +20,7 @@ file_env "DB_DUMP_DEBUG"
 file_env "DB_DUMP_TARGET" "/backup"
 file_env "DB_DUMP_BY_SCHEMA"
 file_env "DB_DUMP_KEEP_PERMISSIONS" "true"
+file_env "DB_DUMP_ARCHIVE_DAYS_TO_KEEP"
 
 file_env "DB_RESTORE_TARGET"
 
@@ -221,6 +222,10 @@ else
       target_time=$(($target_time + $extra_time))
       # Calculate the wait time
       waittime=$(($target_time - $current_time))
+    fi
+    if [[ -n "$DB_DUMP_ARCHIVE_DAYS_TO_KEEP" ]]; then
+      echo Removing Archives older than $DB_DUMP_ARCHIVE_DAYS_TO_KEEP days
+      find $DB_DUMP_TARGET -mtime +$DB_DUMP_ARCHIVE_DAYS_TO_KEEP -exec rm {} \;
     fi
     sleep $waittime
     last_run=$(date +"%s")

--- a/functions.sh
+++ b/functions.sh
@@ -450,3 +450,12 @@ function max_day_in_month() {
       ;;
   esac
 }
+
+function delete_old_backups() {
+    if [[ -n "$DB_DUMP_ARCHIVE_DAYS_TO_KEEP" ]]; then
+      echo Removing Archives older than $DB_DUMP_ARCHIVE_DAYS_TO_KEEP days
+      [[ "$DB_DUMP_DEBUG" != "0" ]] && find $DB_DUMP_TARGET -mtime +$DB_DUMP_ARCHIVE_DAYS_TO_KEEP -exec echo "removing {}" \;
+      find $DB_DUMP_TARGET -mtime +$DB_DUMP_ARCHIVE_DAYS_TO_KEEP -exec rm {} \;
+    fi
+}
+


### PR DESCRIPTION
Added a function that runs at the end of the loop to check for back ups that are older that x amount of days, and removes them automatically. 

Use the env DB_DUMP_ARCHIVE_DAYS_TO_KEEP to set the number of days to keep. 

If this variable is not set, backups are kept indefinitely. 



