### PR TITLE
ensure format is correct

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -173,7 +173,7 @@ else
     target_time=$(($current_time + $waittime))
   else
     today=$(date +"%Y%m%d")
-    target_time=$(date --date="${today}${DB_DUMP_BEGIN}" +"%s")
+    target_time=$(date --date="${today}T${DB_DUMP_BEGIN}" +"%s")
 
     if [[ "$target_time" < "$current_time" ]]; then
       target_time=$(($target_time + 24*60*60))


### PR DESCRIPTION
Fixes #174 

The following is the current date format:

```sh
date --date="${today}${DB_DUMP_BEGIN}" +"%s"
```

It works fine if `today` is set and `DB_DUMP_BEGIN` is not, leading to something like:

```sh
date --date="20211210" +"%s"
```

However, if `DB_DUMP_BEGIN` is set, you end up with:

```sh
date --date="202112100100" +"%s"
```

which is invalid. You need a `T` between them for it to be valid:

```sh
date --date="20211210T0100" +"%s"
```
