### PR TITLE
Re-submitted PR 139 to exclude databases (but without timezone handling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
-* `DB_NAMES`: names of databases to dump; defaults to all databases in the database server
+* `DB_NAMES`: names of databases to dump (separated by space); defaults to all databases in the database server
+* `DB_NAMES_EXCLUDE`: names of databases (separated by space) to exclude from the dump; `information_schema`. `performance_schema`, `sys` and `mysql` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then theese two databases will not be dumped by mysqldump
 * `SINGLE_DATABASE`: If is set to `true`, mysqldump command will run without `--databases` flag. This avoid `USE <database>;` statement which is useful for the cases in which you want to import the dumpfile into a database with a different name.
 * `DB_DUMP_FREQ`: How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 * `DB_DUMP_BEGIN`: What time to do the first dump. Defaults to immediate. Must be in one of two formats:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
 * `DB_NAMES`: names of databases to dump (separated by space); defaults to all databases in the database server
-* `DB_NAMES_EXCLUDE`: names of databases (separated by space) to exclude from the dump; `information_schema`. `performance_schema`, `sys` and `mysql` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then theese two databases will not be dumped by mysqldump
+* `DB_NAMES_EXCLUDE`: names of databases (separated by space) to exclude from the dump; `information_schema`. `performance_schema`, `sys` and `mysql` are excluded by default. This only applies if `DB_DUMP_BY_SCHEMA` is set to `true`. For example, if you set `DB_NAMES_EXCLUDE=database1 db2` and `DB_DUMP_BY_SCHEMA=true` then these two databases will not be dumped by mysqldump
 * `SINGLE_DATABASE`: If is set to `true`, mysqldump command will run without `--databases` flag. This avoid `USE <database>;` statement which is useful for the cases in which you want to import the dumpfile into a database with a different name.
 * `DB_DUMP_FREQ`: How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 * `DB_DUMP_BEGIN`: What time to do the first dump. Defaults to immediate. Must be in one of two formats:

--- a/entrypoint
+++ b/entrypoint
@@ -13,6 +13,7 @@ file_env "DB_PORT"
 file_env "DB_USER"
 file_env "DB_PASS"
 file_env "DB_NAMES"
+file_env "DB_NAMES_EXCLUDE"
 
 file_env "DB_DUMP_FREQ" "1440"
 file_env "DB_DUMP_BEGIN" "+0"

--- a/functions.sh
+++ b/functions.sh
@@ -128,16 +128,16 @@ function do_dump() {
       DB_NAMES=$(mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS -N -e 'show databases')
       [ $? -ne 0 ] && return 1
     fi
-    if [[ -n "$DB_NAMES_EXCLUDE" ]]; then
-      # exclude databases if specificied
-      DB_NAMES_EXCLUDE=(`echo $DB_NAMES_EXCLUDE`)
-    else
-      # if not -> exclude the default ones
-      DB_NAMES_EXCLUDE=(information_schema performance_schema mysql sys)
+    if [ -z "$DB_NAMES_EXCLUDE" ]; then
+      DB_NAMES_EXCLUDE="information_schema performance_schema mysql sys"
     fi
+    declare -A exclude_list
+    for i in $DB_NAMES_EXCLUDE; do
+      exclude_list[$i]="true"
+    done
     for onedb in $DB_NAMES; do
-      if [[ " ${DB_NAMES_EXCLUDE[@]} " =~ " ${onedb} " ]]; then
-        # skip database if on exclude list
+      if [ -v exclude_list[$onedb] ]; then
+        # skip db if it is in the exclude list
         continue
       fi
       $NICE_CMD mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${onedb} $MYSQLDUMP_OPTS > $workdir/${onedb}_${now}.sql

--- a/functions.sh
+++ b/functions.sh
@@ -128,7 +128,18 @@ function do_dump() {
       DB_NAMES=$(mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS -N -e 'show databases')
       [ $? -ne 0 ] && return 1
     fi
+    if [[ -n "$DB_NAMES_EXCLUDE" ]]; then
+      # exclude databases if specificied
+      DB_NAMES_EXCLUDE=(`echo $DB_NAMES_EXCLUDE`)
+    else
+      # if not -> exclude the default ones
+      DB_NAMES_EXCLUDE=(information_schema performance_schema mysql sys)
+    fi
     for onedb in $DB_NAMES; do
+      if [[ " ${DB_NAMES_EXCLUDE[@]} " =~ " ${onedb} " ]]; then
+        # skip database if on exclude list
+        continue
+      fi
       $NICE_CMD mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${onedb} $MYSQLDUMP_OPTS > $workdir/${onedb}_${now}.sql
       [ $? -ne 0 ] && return 1
     done


### PR DESCRIPTION
I recently had the same issues with the "information_schema" database when using mysqldump. Even after reading a lot of pages I could not find a solution to dump the various internal database without any issue. Also from what I understood it also is not useful to do backups of those DBs at all.

Hence I checked the closed #139 (which addresses #138) and stripped away the timezone handling stuff as this is a topic on its own. I also change the spelling corrections you mentioned. Last but not least I did a few tests with the changed code. It seems to work as expected.

So I'm asking to to consider this pull request. If you see any issues or changes needed just let me know. I will try to help as good as I can.