### PR TITLE
Restore single database

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
+* `DB_NAMES`: name of database to restore to. Required if `SINGLE_DATABASE=true`, otherwise has no effect. Although the name is plural, it must contain exactly one database name.
+* `SINGLE_DATABASE`: If is set to `true`, `DB_NAMES` is required and mysql command will run with `--database=$DB_NAMES` flag. This avoids the need of `USE <database>;` statement, which is useful when restoring from a file saved with `SINGLE_DATABASE` set to `true`.
 * `DB_RESTORE_TARGET`: path to the actual restore file, which should be a compressed dump file. The target can be an absolute path, which should be volume mounted, an smb or S3 URL, similar to the target.
 * `DB_DUMP_DEBUG`: if `true`, dump copious outputs to the container logs while restoring.
 * To use the S3 driver `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` will need to be defined.

--- a/entrypoint
+++ b/entrypoint
@@ -136,11 +136,16 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
   fi
   # did we get a file?
   if [[ -f "$TMPRESTORE" ]]; then
+    if [ "$SINGLE_DATABASE" = "true" ]; then
+      DBDATABASE="-D$DB_NAMES"
+    else
+      DBDATABASE=
+    fi
     workdir="${TMP_PATH}/restore.$$"
     rm -rf $workdir
     mkdir -p $workdir
     $UNCOMPRESS < $TMPRESTORE | tar -C $workdir -xvf -
-    cat $workdir/* | mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS
+    cat $workdir/* | mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DBDATABASE
     rm -rf $workdir
     /bin/rm -f $TMPRESTORE
   else


### PR DESCRIPTION
Currently, the docker image has no way to restore a database saved with the option `SINGLE_DATABASE=true`. This pull request makes it possible.

Specify `SINGLE_DATABASE=true` and `DB_NAMES` variable along with `DB_RESTORE_TARGET` to restore a single database to the database named `DB_NAMES`. `DB_NAMES` is expected to contain one database name, not space-separated multiple database names despite its plural variable name.

Implementation of #121.