### PR TITLE
Restore specific schema from archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
-* `DB_NAMES`: can be used in two distinct cases:
-  * `SINGLE_DATABASE` has been set to `true`: in that case it specifies the name of the database to restore to, and it must contain exactly one database name.
-  * `SINGLE_DATABASE` has not been set to `true` and `DB_DUMP_BY_SCHEMA=true` was used for backup: in that case it specifies which schemas to restore. It can contain one or more schema names separated with spaces.
+* `DB_NAMES`: if `SINGLE_DATABASE` is `true`, __must__ contain the name of exactly one database. Else, __can__ contain one or more schemas to be restored from the `DB_RESTORE_TARGET`, separated by spaces. Second option only works if the target backup was dumped using `DB_DUMP_BY_SCHEMA`.
 * `SINGLE_DATABASE`: If is set to `true`, `DB_NAMES` is required and mysql command will run with `--database=$DB_NAMES` flag. This avoids the need of `USE <database>;` statement, which is useful when restoring from a file saved with `SINGLE_DATABASE` set to `true`.
 * `DB_RESTORE_TARGET`: path to the actual restore file, which should be a compressed dump file. The target can be an absolute path, which should be volume mounted, an smb or S3 URL, similar to the target.
 * `RESTORE_OPTS`: A string of options to pass to  `mysql` restore command, e.g. `--ssl-cert /certs/client-cert.pem --ssl-key /certs/client-key.pem` will run `mysql --ssl-cert /certs/client-cert.pem --ssl-key /certs/client-key.pem -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DBDATABASE`, default is empty ('')

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
-* `DB_NAMES`: name of database to restore to. Required if `SINGLE_DATABASE=true`, otherwise has no effect. Although the name is plural, it must contain exactly one database name.
+* `DB_NAMES`: can be used in two distinct cases:
+  * `SINGLE_DATABASE` has been set to `true`: in that case it specifies the name of the database to restore to, and it must contain exactly one database name.
+  * `SINGLE_DATABASE` has not been set to `true` and `DB_DUMP_BY_SCHEMA=true` was used for backup: in that case it specifies which schemas to restore. It can contain one or more schema names separated with spaces.
 * `SINGLE_DATABASE`: If is set to `true`, `DB_NAMES` is required and mysql command will run with `--database=$DB_NAMES` flag. This avoids the need of `USE <database>;` statement, which is useful when restoring from a file saved with `SINGLE_DATABASE` set to `true`.
 * `DB_RESTORE_TARGET`: path to the actual restore file, which should be a compressed dump file. The target can be an absolute path, which should be volume mounted, an smb or S3 URL, similar to the target.
 * `RESTORE_OPTS`: A string of options to pass to  `mysql` restore command, e.g. `--ssl-cert /certs/client-cert.pem --ssl-key /certs/client-key.pem` will run `mysql --ssl-cert /certs/client-cert.pem --ssl-key /certs/client-key.pem -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DBDATABASE`, default is empty ('')

--- a/entrypoint
+++ b/entrypoint
@@ -146,7 +146,17 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
     mkdir -p $workdir
     $UNCOMPRESS < $TMPRESTORE | tar -C $workdir -xvf -
     RESTORE_OPTS=${RESTORE_OPTS:-}
-    cat $workdir/* | mysql $RESTORE_OPTS -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DBDATABASE
+    # If there are multiple schemas in the archive (e.g. DB_DUMP_BY_SCHEMA was used) and DB_NAMES is set,
+    # restore only the required databases
+    if [[ $(ls -1q $workdir/* | wc -l) -gt 1 ]] && [[ -n "$DB_NAMES" ]]; then
+      for onedb in $DB_NAMES; do
+        echo "Restoring $onedb from " $workdir/$onedb*
+        # /!\ If a schema has a name that begins with another one, it will executed multiple times the other one
+        cat $workdir/$onedb* | mysql $RESTORE_OPTS -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS
+      done
+    else
+      cat $workdir/* | mysql $RESTORE_OPTS -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DBDATABASE
+    fi
     rm -rf $workdir
     /bin/rm -f $TMPRESTORE
   else

--- a/entrypoint
+++ b/entrypoint
@@ -148,7 +148,7 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
     RESTORE_OPTS=${RESTORE_OPTS:-}
     # If there are multiple schemas in the archive (e.g. DB_DUMP_BY_SCHEMA was used) and DB_NAMES is set,
     # restore only the required databases
-    if [[ $(ls -1q $workdir/* | wc -l) -gt 1 ]] && [[ -n "$DB_NAMES" ]]; then
+    if [ "$SINGLE_DATABASE" != "true" ] && [[ $(ls -1q $workdir/* | wc -l) -gt 1 ]] && [[ -n "$DB_NAMES" ]]; then
       for onedb in $DB_NAMES; do
         echo "Restoring $onedb from " $workdir/$onedb*
         # /!\ If a schema has a name that begins with another one, it will executed multiple times the other one


### PR DESCRIPTION
Use the `DB_NAMES` variable without `SINGLE_DATABASE` to specify one or more databases to restore from a backup archive generated with `DB_DUMP_BY_SCHEMA`.

I am not a bash expert, so feel free to test and review my code. I tested it for simple cases without errors. Also, as I made it, there can be issues when schema names are overlapping.