### PR TITLE
Fix parsing begin time flag

### DIFF
--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -93,7 +93,7 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 			// convert that start time into a Duration to wait
 			now := time.Now()
 
-			today := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, now.Second(), now.Nanosecond(), time.Local)
+			today := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, now.Second(), now.Nanosecond(), time.UTC)
 			if today.After(now) {
 				delay = today.Sub(now)
 			} else {

--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -80,7 +80,7 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 				return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
 			}
 			delay = time.Duration(delayMins) * time.Minute
-		case len(startTimeParts) > 3:
+		case len(startTimeParts) > 2:
 			hour, err := strconv.Atoi(startTimeParts[1])
 			if err != nil {
 				return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
@@ -93,7 +93,7 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 			// convert that start time into a Duration to wait
 			now := time.Now()
 
-			today := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, now.Second(), now.Nanosecond(), time.UTC)
+			today := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, now.Second(), now.Nanosecond(), time.Local)
 			if today.After(now) {
 				delay = today.Sub(now)
 			} else {

--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -118,7 +118,7 @@ func waitForBeginTime(begin string, from time.Time) (time.Duration, error) {
 	if err != nil {
 		return time.Duration(0), fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
 	}
-	timeRe, err := regexp.Compile(`([0-9][0-9])([0-9][0-9])`)
+	timeRe, err := regexp.Compile(`^([0-9][0-9])([0-9][0-9])$`)
 	if err != nil {
 		return time.Duration(0), fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
 	}

--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -59,49 +59,10 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 		}
 	}
 	if opts.Begin != "" {
-		// calculate how long to wait
-		minsRe, err := regexp.Compile(`^\+([0-9]+)$`)
+		// calculate delay based on begin time
+		delay, err = waitForBeginTime(opts.Begin, now)
 		if err != nil {
-			return nil, fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
-		}
-		timeRe, err := regexp.Compile(`([0-9][0-9])([0-9][0-9])`)
-		if err != nil {
-			return nil, fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
-		}
-
-		// first look for +MM, which means delay MM minutes
-		delayMinsParts := minsRe.FindStringSubmatch(opts.Begin)
-		startTimeParts := timeRe.FindStringSubmatch(opts.Begin)
-
-		switch {
-		case len(delayMinsParts) > 1:
-			delayMins, err := strconv.Atoi(delayMinsParts[1])
-			if err != nil {
-				return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
-			}
-			delay = time.Duration(delayMins) * time.Minute
-		case len(startTimeParts) > 2:
-			hour, err := strconv.Atoi(startTimeParts[1])
-			if err != nil {
-				return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
-			}
-			minute, err := strconv.Atoi(startTimeParts[2])
-			if err != nil {
-				return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
-			}
-
-			// convert that start time into a Duration to wait
-			now := time.Now()
-
-			today := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, now.Second(), now.Nanosecond(), time.UTC)
-			if today.After(now) {
-				delay = today.Sub(now)
-			} else {
-				// add one day
-				delay = today.Add(24 * time.Hour).Sub(now)
-			}
-		default:
-			return nil, fmt.Errorf("invalid format for begin delay '%s': %v", opts.Begin, err)
+			return nil, fmt.Errorf("invalid begin option '%s': %v", opts.Begin, err)
 		}
 	}
 
@@ -148,6 +109,54 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 		}
 	}(opts)
 	return c, nil
+}
+
+func waitForBeginTime(begin string, from time.Time) (time.Duration, error) {
+
+	// calculate how long to wait
+	minsRe, err := regexp.Compile(`^\+([0-9]+)$`)
+	if err != nil {
+		return time.Duration(0), fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
+	}
+	timeRe, err := regexp.Compile(`([0-9][0-9])([0-9][0-9])`)
+	if err != nil {
+		return time.Duration(0), fmt.Errorf("invalid matcher for checking begin delay options: %v", err)
+	}
+
+	// first look for +MM, which means delay MM minutes
+	delayMinsParts := minsRe.FindStringSubmatch(begin)
+	startTimeParts := timeRe.FindStringSubmatch(begin)
+
+	var delay time.Duration
+	switch {
+	case len(delayMinsParts) > 1:
+		delayMins, err := strconv.Atoi(delayMinsParts[1])
+		if err != nil {
+			return time.Duration(0), fmt.Errorf("invalid format for begin delay '%s': %v", begin, err)
+		}
+		delay = time.Duration(delayMins) * time.Minute
+	case len(startTimeParts) > 2:
+		hour, err := strconv.Atoi(startTimeParts[1])
+		if err != nil {
+			return time.Duration(0), fmt.Errorf("invalid format for begin delay '%s': %v", begin, err)
+		}
+		minute, err := strconv.Atoi(startTimeParts[2])
+		if err != nil {
+			return time.Duration(0), fmt.Errorf("invalid format for begin delay '%s': %v", begin, err)
+		}
+
+		// convert that start time into a Duration to wait
+		today := time.Date(from.Year(), from.Month(), from.Day(), hour, minute, from.Second(), from.Nanosecond(), time.UTC)
+		if today.After(from) {
+			delay = today.Sub(from)
+		} else {
+			// add one day
+			delay = today.Add(24 * time.Hour).Sub(from)
+		}
+	default:
+		return time.Duration(0), fmt.Errorf("invalid format for begin delay '%s'", begin)
+	}
+	return delay, nil
 }
 
 // waitForCron given the current time and a cron string, calculate the Duration

--- a/pkg/core/timer_test.go
+++ b/pkg/core/timer_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -32,6 +33,40 @@ func TestWaitForCron(t *testing.T) {
 				t.Errorf("waitForCron(%s, %s) error = %v, wantErr %v", tt.cron, tt.from, err, tt.err)
 			case result != tt.wait:
 				t.Errorf("waitForCron(%s, %s) = %v, want %v", tt.cron, tt.from, result, tt.wait)
+			}
+		})
+	}
+}
+
+func TestWaitForBeginTime(t *testing.T) {
+	tests := []struct {
+		name  string
+		begin string
+		from  string
+		wait  time.Duration
+		err   error
+	}{
+		{"wait one minute", "+1", "2018-10-10T10:00:00Z", 1 * time.Minute, nil},
+		{"wait 999999 minutes", "+999999", "2018-10-10T10:00:00Z", 999999 * time.Minute, nil},
+		{"wait until 10:23", "1023", "2018-10-10T10:00:00Z", 23 * time.Minute, nil},
+		{"wait until 23:59", "2359", "2018-10-10T10:00:00Z", 13*time.Hour + 59*time.Minute, nil},
+		{"wait until 9:59", "0959", "2018-10-10T10:00:00Z", 23*time.Hour + 59*time.Minute, nil},
+		{"fail text", "today", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay 'today'")},
+		{"fail number", "1", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay '1'")},
+		{"fail +hour", "+1h", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay '+1h'")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := time.Parse(time.RFC3339, tt.from)
+			if err != nil {
+				t.Fatalf("unable to parse from %s: %v", tt.from, err)
+			}
+			result, err := waitForBeginTime(tt.begin, from)
+			switch {
+			case (err != nil && tt.err == nil) || (err == nil && tt.err != nil) || (err != nil && tt.err != nil && err.Error() != tt.err.Error()):
+				t.Errorf("waitForBeginTime(%s, %s) error = %v, wantErr %v", tt.begin, tt.from, err, tt.err)
+			case result != tt.wait:
+				t.Errorf("waitForBeginTime(%s, %s) = %v, want %v", tt.begin, tt.from, result, tt.wait)
 			}
 		})
 	}

--- a/pkg/core/timer_test.go
+++ b/pkg/core/timer_test.go
@@ -51,9 +51,11 @@ func TestWaitForBeginTime(t *testing.T) {
 		{"wait until 10:23", "1023", "2018-10-10T10:00:00Z", 23 * time.Minute, nil},
 		{"wait until 23:59", "2359", "2018-10-10T10:00:00Z", 13*time.Hour + 59*time.Minute, nil},
 		{"wait until 9:59", "0959", "2018-10-10T10:00:00Z", 23*time.Hour + 59*time.Minute, nil},
+		{"pass time over 24h", "2401", "2018-10-10T10:00:00Z", 14*time.Hour + time.Minute, nil}, //time.Time accepts values outside the usual ranges
 		{"fail text", "today", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay 'today'")},
 		{"fail number", "1", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay '1'")},
 		{"fail +hour", "+1h", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay '+1h'")},
+		{"fail too long time", "12345", "2018-10-10T10:00:00Z", time.Duration(0), fmt.Errorf("invalid format for begin delay '12345'")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #267 
- Parsing of start time failed, because regex produces 3 matching groups, not more