### PR TITLE
use UTC for timer as well to be consistent

### DIFF
--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -39,7 +39,7 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 		err   error
 	)
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// validate we do not have conflicting options
 	if opts.Once && (opts.Cron != "" || opts.Begin != "" || opts.Frequency != 0) {


### PR DESCRIPTION
Per [this comment](https://github.com/databacker/mysql-backup/issues/267#issuecomment-1943722777)

We may add timezone support in the future, but for now we should consistent.