### PR TITLE
Add support for TIMESTAMP, DATETIME, DATE fields

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -18,6 +18,7 @@ func (c Connection) MySQL() string {
 	config.User = c.User
 	config.Passwd = c.Pass
 	config.Net = "tcp"
+	config.ParseTime = true
 	config.Addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
 	return config.FormatDSN()
 }

--- a/pkg/database/mysql/dump.go
+++ b/pkg/database/mysql/dump.go
@@ -557,6 +557,13 @@ func (table *table) RowBuffer() *bytes.Buffer {
 			} else {
 				fmt.Fprintf(&b, "_binary '%s'", sanitize(string(*s)))
 			}
+		case *sql.NullTime:
+			if s.Valid {
+				fmt.Fprintf(&b, "'%s'", sanitize(s.Time.Format("2006-01-02 15:04:05")))
+			} else {
+				b.WriteString(nullType)
+			}
+
 		default:
 			fmt.Fprintf(&b, "'%s'", value)
 		}

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -303,7 +303,7 @@ func (d *dockerContext) createBackupFile(mysqlCID, mysqlUser, mysqlPass, outfile
 	ctx := context.Background()
 
 	// Create and populate the table
-	mysqlCreateCmd := []string{"mysql", "-hlocalhost", "--protocol=tcp", fmt.Sprintf("-u%s", mysqlUser), fmt.Sprintf("-p%s", mysqlPass), "-e", `use tester; create table t1 (id INT, name VARCHAR(20)); INSERT INTO t1 (id,name) VALUES (1, "John"), (2, "Jill"), (3, "Sam"), (4, "Sarah");`}
+	mysqlCreateCmd := []string{"mysql", "-hlocalhost", "--protocol=tcp", fmt.Sprintf("-u%s", mysqlUser), fmt.Sprintf("-p%s", mysqlPass), "-e", `use tester; create table t1 (id INT, name VARCHAR(20), test_timestamp TIMESTAMP, test_datetime DATETIME, test_date DATE, test_time TIME); INSERT INTO t1 (id,name,test_timestamp,test_datetime,test_date,test_time) VALUES (1, "John", '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00'), (2, "Jill", '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00'), (3, "Sam", '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00'), (4, "Sarah", '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00', '2012-11-01 00:15:00');`}
 	attachResp, exitCode, err := d.execInContainer(ctx, mysqlCID, mysqlCreateCmd)
 	if err != nil {
 		return fmt.Errorf("failed to attach to exec: %w", err)


### PR DESCRIPTION
- enable time parsing in mysql connection option
- add parsing of time values for printing dump file
- adjust integration test to use: TIMESTAMP, DATETIME, DATE and TIME fields

Integration test currently fails, as DATE and TIME fields are printed as full datetime strings.

```sql
INSERT INTO `t1` (`id`, `name`, `test_timestamp`, `test_datetime`, `test_date`, `test_time`)
VALUES (1,'John','2012-11-01 00:15:00','2012-11-01 00:15:00','2012-11-01','00:15:00');
```
```sql
INSERT INTO `t1` (`id`, `name`, `test_timestamp`, `test_datetime`, `test_date`, `test_time`)
VALUES (1,'John','2012-11-01 00:15:00','2012-11-01 00:15:00','2012-11-01 00:00:00',_binary '00:15:00');
```

To fix this, the RowBuffer method would have to be aware of the SQL field type, to distinguish between e.g DATE and DATETIME for the formatting. This would be a bigger change @deitch maybe you have an idea on how to handle that, or just adjust the test to ignore it. 
The currently produced output still works when restoring the backup.

Close #272 