### PR TITLE
enable retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Back up mysql databases to... anywhere!
 
 ## Overview
 
-mysql-backup is a simple way to do MySQL database backups and restores.
+mysql-backup is a simple way to do MySQL database backups and restores, as well as manage your backups.
 
 It has the following features:
 
@@ -14,6 +14,7 @@ It has the following features:
 * connect to any container running on the same system
 * select how often to run a dump
 * select when to start the first dump, whether time of day or relative to container start time
+* prune backups older than a specific time period or quantity
 
 Please see [CONTRIBUTORS.md](./CONTRIBUTORS.md) for a list of contributors.
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -17,12 +17,25 @@ func newMockExecs() *mockExecs {
 	return m
 }
 
-func (m *mockExecs) timerDump(opts core.DumpOptions, timerOpts core.TimerOptions) error {
-	args := m.Called(opts, timerOpts)
+func (m *mockExecs) dump(opts core.DumpOptions) error {
+	args := m.Called(opts)
 	return args.Error(0)
 }
 
 func (m *mockExecs) restore(target storage.Storage, targetFile string, dbconn database.Connection, databasesMap map[string]string, compressor compression.Compressor) error {
 	args := m.Called(target, targetFile, dbconn, databasesMap, compressor)
 	return args.Error(0)
+}
+
+func (m *mockExecs) prune(opts core.PruneOptions) error {
+	args := m.Called(opts)
+	return args.Error(0)
+}
+func (m *mockExecs) timer(timerOpts core.TimerOptions, cmd func() error) error {
+	args := m.Called(timerOpts)
+	err := args.Error(0)
+	if err != nil {
+		return err
+	}
+	return cmd()
 }

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -20,7 +20,10 @@ const (
 	defaultMaxAllowedPacket = 4194304
 )
 
-func dumpCmd(execs execs) (*cobra.Command, error) {
+func dumpCmd(execs execs, cmdConfig *cmdConfiguration) (*cobra.Command, error) {
+	if cmdConfig == nil {
+		return nil, fmt.Errorf("cmdConfig is nil")
+	}
 	var v *viper.Viper
 	var cmd = &cobra.Command{
 		Use:     "dump",
@@ -43,7 +46,7 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 			)
 			if len(targetURLs) > 0 {
 				for _, t := range targetURLs {
-					store, err := storage.ParseURL(t, creds)
+					store, err := storage.ParseURL(t, cmdConfig.creds)
 					if err != nil {
 						return fmt.Errorf("invalid target url: %v", err)
 					}
@@ -51,10 +54,10 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				}
 			} else {
 				// try the config file
-				if configuration != nil {
+				if cmdConfig.configuration != nil {
 					// parse the target objects, then the ones listed for the backup
-					targetStructures := configuration.Targets
-					dumpTargets := configuration.Dump.Targets
+					targetStructures := cmdConfig.configuration.Targets
+					dumpTargets := cmdConfig.configuration.Dump.Targets
 					for _, t := range dumpTargets {
 						var store storage.Storage
 						if target, ok := targetStructures[t]; !ok {
@@ -73,40 +76,40 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				return fmt.Errorf("no targets specified")
 			}
 			safechars := v.GetBool("safechars")
-			if !v.IsSet("safechars") && configuration != nil {
-				safechars = configuration.Dump.Safechars
+			if !v.IsSet("safechars") && cmdConfig.configuration != nil {
+				safechars = cmdConfig.configuration.Dump.Safechars
 			}
 			include := v.GetStringSlice("include")
-			if len(include) == 0 && configuration != nil {
-				include = configuration.Dump.Include
+			if len(include) == 0 && cmdConfig.configuration != nil {
+				include = cmdConfig.configuration.Dump.Include
 			}
 			// make this slice nil if it's empty, so it is consistent; used mainly for test consistency
 			if len(include) == 0 {
 				include = nil
 			}
 			exclude := v.GetStringSlice("exclude")
-			if len(exclude) == 0 && configuration != nil {
-				exclude = configuration.Dump.Exclude
+			if len(exclude) == 0 && cmdConfig.configuration != nil {
+				exclude = cmdConfig.configuration.Dump.Exclude
 			}
 			// make this slice nil if it's empty, so it is consistent; used mainly for test consistency
 			if len(exclude) == 0 {
 				exclude = nil
 			}
 			preBackupScripts := v.GetString("pre-backup-scripts")
-			if preBackupScripts == "" && configuration != nil {
-				preBackupScripts = configuration.Dump.Scripts.PreBackup
+			if preBackupScripts == "" && cmdConfig.configuration != nil {
+				preBackupScripts = cmdConfig.configuration.Dump.Scripts.PreBackup
 			}
 			noDatabaseName := v.GetBool("no-database-name")
-			if !v.IsSet("no-database-name") && configuration != nil {
-				noDatabaseName = configuration.Dump.NoDatabaseName
+			if !v.IsSet("no-database-name") && cmdConfig.configuration != nil {
+				noDatabaseName = cmdConfig.configuration.Dump.NoDatabaseName
 			}
 			compact := v.GetBool("compact")
-			if !v.IsSet("compact") && configuration != nil {
-				compact = configuration.Dump.Compact
+			if !v.IsSet("compact") && cmdConfig.configuration != nil {
+				compact = cmdConfig.configuration.Dump.Compact
 			}
 			maxAllowedPacket := v.GetInt("max-allowed-packet")
-			if !v.IsSet("max-allowed-packet") && configuration != nil && configuration.Dump.MaxAllowedPacket != 0 {
-				maxAllowedPacket = configuration.Dump.MaxAllowedPacket
+			if !v.IsSet("max-allowed-packet") && cmdConfig.configuration != nil && cmdConfig.configuration.Dump.MaxAllowedPacket != 0 {
+				maxAllowedPacket = cmdConfig.configuration.Dump.MaxAllowedPacket
 			}
 
 			// compression algorithm: check config, then CLI/env var overrides
@@ -114,8 +117,8 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				compressionAlgo string
 				compressor      compression.Compressor
 			)
-			if configuration != nil {
-				compressionAlgo = configuration.Dump.Compression
+			if cmdConfig.configuration != nil {
+				compressionAlgo = cmdConfig.configuration.Dump.Compression
 			}
 			compressionVar := v.GetString("compression")
 			if compressionVar != "" {
@@ -131,7 +134,7 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				Targets:             targets,
 				Safechars:           safechars,
 				DBNames:             include,
-				DBConn:              dbconn,
+				DBConn:              cmdConfig.dbconn,
 				Compressor:          compressor,
 				Exclude:             exclude,
 				PreBackupScripts:    preBackupScripts,
@@ -141,22 +144,28 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				MaxAllowedPacket:    maxAllowedPacket,
 			}
 
+			// retention, if enabled
+			retention := v.GetString("retention")
+			if retention == "" && cmdConfig.configuration != nil {
+				retention = cmdConfig.configuration.Prune.Retention
+			}
+
 			// timer options
 			once := v.GetBool("once")
-			if !v.IsSet("once") && configuration != nil {
-				once = configuration.Dump.Schedule.Once
+			if !v.IsSet("once") && cmdConfig.configuration != nil {
+				once = cmdConfig.configuration.Dump.Schedule.Once
 			}
 			cron := v.GetString("cron")
-			if cron == "" && configuration != nil {
-				cron = configuration.Dump.Schedule.Cron
+			if cron == "" && cmdConfig.configuration != nil {
+				cron = cmdConfig.configuration.Dump.Schedule.Cron
 			}
 			begin := v.GetString("begin")
-			if begin == "" && configuration != nil {
-				begin = configuration.Dump.Schedule.Begin
+			if begin == "" && cmdConfig.configuration != nil {
+				begin = cmdConfig.configuration.Dump.Schedule.Begin
 			}
 			frequency := v.GetInt("frequency")
-			if frequency == 0 && configuration != nil {
-				frequency = configuration.Dump.Schedule.Frequency
+			if frequency == 0 && cmdConfig.configuration != nil {
+				frequency = cmdConfig.configuration.Dump.Schedule.Frequency
 			}
 			timerOpts := core.TimerOptions{
 				Once:      once,
@@ -164,12 +173,27 @@ func dumpCmd(execs execs) (*cobra.Command, error) {
 				Begin:     begin,
 				Frequency: frequency,
 			}
-			dump := core.TimerDump
+			dump := core.Dump
+			prune := core.Prune
+			timer := core.TimerCommand
 			if execs != nil {
-				dump = execs.timerDump
+				dump = execs.dump
+				prune = execs.prune
+				timer = execs.timer
 			}
-			if err := dump(dumpOpts, timerOpts); err != nil {
-				return err
+			if err := timer(timerOpts, func() error {
+				err := dump(dumpOpts)
+				if err != nil {
+					return fmt.Errorf("error running dump: %w", err)
+				}
+				if retention != "" {
+					if err := prune(core.PruneOptions{Targets: targets, Retention: retention}); err != nil {
+						return fmt.Errorf("error running prune: %w", err)
+					}
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("error running command: %w", err)
 			}
 			log.Info("Backup complete")
 			return nil
@@ -232,6 +256,8 @@ S3: If it is a URL of the format s3://bucketname/path then it will connect via S
 	cmd.MarkFlagsMutuallyExclusive("once", "frequency")
 	cmd.MarkFlagsMutuallyExclusive("cron", "begin")
 	cmd.MarkFlagsMutuallyExclusive("cron", "frequency")
+	// retention
+	flags.String("retention", "", "Retention period for backups. Optional. If not specified, no pruning will be done. Can be number of backups or time-based. For time-based, the format is: 1d, 1w, 1m, 1y for days, weeks, months, years, respectively. For number-based, the format is: 1c, 2c, 3c, etc. for the count of backups to keep.")
 
 	return cmd, nil
 }

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -25,63 +25,80 @@ func TestDumpCmd(t *testing.T) {
 		wantErr              bool
 		expectedDumpOptions  core.DumpOptions
 		expectedTimerOptions core.TimerOptions
+		expectedPruneOptions *core.PruneOptions
 	}{
-		{"missing server and target options", []string{""}, "", true, core.DumpOptions{}, core.TimerOptions{}},
-		{"invalid target URL", []string{"--server", "abc", "--target", "def"}, "", true, core.DumpOptions{DBConn: database.Connection{Host: "abc"}}, core.TimerOptions{}},
+		// invalid ones
+		{"missing server and target options", []string{""}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
+		{"invalid target URL", []string{"--server", "abc", "--target", "def"}, "", true, core.DumpOptions{DBConn: database.Connection{Host: "abc"}}, core.TimerOptions{}, nil},
+
+		// file URL
 		{"file URL", []string{"--server", "abc", "--target", "file:///foo/bar"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},
 			MaxAllowedPacket: defaultMaxAllowedPacket,
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           database.Connection{Host: "abc"},
-		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+		{"file URL with prune", []string{"--server", "abc", "--target", "file:///foo/bar", "--retention", "1h"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           database.Connection{Host: "abc"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
+
+		// config file
+		{"config file", []string{"--config-file", "testdata/config.yml"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           database.Connection{Host: "abcd", Port: 3306, User: "user2", Pass: "xxxx2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
+
+		// timer options
 		{"once flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--once"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},
 			MaxAllowedPacket: defaultMaxAllowedPacket,
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           database.Connection{Host: "abc"},
-		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin, Once: true}},
+		}, core.TimerOptions{Once: true, Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"cron flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},
 			MaxAllowedPacket: defaultMaxAllowedPacket,
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           database.Connection{Host: "abc"},
-		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin, Cron: "0 0 * * *"}},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin, Cron: "0 0 * * *"}, nil},
 		{"begin flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--begin", "1234"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},
 			MaxAllowedPacket: defaultMaxAllowedPacket,
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           database.Connection{Host: "abc"},
-		}, core.TimerOptions{Frequency: defaultFrequency, Begin: "1234"}},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: "1234"}, nil},
 		{"frequency flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--frequency", "10"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},
 			MaxAllowedPacket: defaultMaxAllowedPacket,
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           database.Connection{Host: "abc"},
-		}, core.TimerOptions{Frequency: 10, Begin: defaultBegin}},
-		{"config file", []string{"--config-file", "testdata/config.yml"}, "", false, core.DumpOptions{
-			Targets:          []storage.Storage{file.New(*fileTargetURL)},
-			MaxAllowedPacket: defaultMaxAllowedPacket,
-			Compressor:       &compression.GzipCompressor{},
-			DBConn:           database.Connection{Host: "abc", Port: 3306, User: "user", Pass: "xxxx"},
-		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}},
-		{"incompatible flags: once/cron", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--cron", "0 0 * * *"}, "", true, core.DumpOptions{}, core.TimerOptions{}},
-		{"incompatible flags: once/begin", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--begin", "1234"}, "", true, core.DumpOptions{}, core.TimerOptions{}},
-		{"incompatible flags: once/frequency", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--frequency", "10"}, "", true, core.DumpOptions{}, core.TimerOptions{}},
-		{"incompatible flags: cron/begin", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *", "--begin", "1234"}, "", true, core.DumpOptions{}, core.TimerOptions{}},
-		{"incompatible flags: cron/frequency", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *", "--frequency", "10"}, "", true, core.DumpOptions{}, core.TimerOptions{}},
+		}, core.TimerOptions{Frequency: 10, Begin: defaultBegin}, nil},
+		{"incompatible flags: once/cron", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--cron", "0 0 * * *"}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
+		{"incompatible flags: once/begin", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--begin", "1234"}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
+		{"incompatible flags: once/frequency", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--frequency", "10"}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
+		{"incompatible flags: cron/begin", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *", "--begin", "1234"}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
+		{"incompatible flags: cron/frequency", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *", "--frequency", "10"}, "", true, core.DumpOptions{
+			DBConn: database.Connection{Host: "abcd", Port: 3306, User: "user2", Pass: "xxxx2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := newMockExecs()
-			m.On("timerDump", mock.MatchedBy(func(dumpOpts core.DumpOptions) bool {
+			m.On("dump", mock.MatchedBy(func(dumpOpts core.DumpOptions) bool {
 				diff := deep.Equal(dumpOpts, tt.expectedDumpOptions)
 				if diff == nil {
 					return true
 				}
 				t.Errorf("dumpOpts compare failed: %v", diff)
 				return false
-			}), mock.MatchedBy(func(timerOpts core.TimerOptions) bool {
+			})).Return(nil)
+			m.On("timer", mock.MatchedBy(func(timerOpts core.TimerOptions) bool {
 				diff := deep.Equal(timerOpts, tt.expectedTimerOptions)
 				if diff == nil {
 					return true
@@ -89,6 +106,16 @@ func TestDumpCmd(t *testing.T) {
 				t.Errorf("timerOpts compare failed: %v", diff)
 				return false
 			})).Return(nil)
+			if tt.expectedPruneOptions != nil {
+				m.On("prune", mock.MatchedBy(func(pruneOpts core.PruneOptions) bool {
+					diff := deep.Equal(pruneOpts, *tt.expectedPruneOptions)
+					if diff == nil {
+						return true
+					}
+					t.Errorf("pruneOpts compare failed: %v", diff)
+					return false
+				})).Return(nil)
+			}
 
 			cmd, err := rootCmd(m)
 			if err != nil {

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/databacker/mysql-backup/pkg/core"
+	"github.com/databacker/mysql-backup/pkg/storage"
+)
+
+func pruneCmd(execs execs, cmdConfig *cmdConfiguration) (*cobra.Command, error) {
+	if cmdConfig == nil {
+		return nil, fmt.Errorf("cmdConfig is nil")
+	}
+	var v *viper.Viper
+	var cmd = &cobra.Command{
+		Use:   "prune",
+		Short: "prune older backups",
+		Long: `Prune older backups based on a retention period. Can be number of backups or time-based.
+		For time-based, the format is: 1d, 1w, 1m, 1y for days, weeks, months, years, respectively.
+		For number-based, the format is: 1c, 2c, 3c, etc. for the count of backups to keep.
+		
+		For time-based, prune always converts the time to hours, and then rounds up. This means that 2d is treated as 48h, and
+		any backups must be at least 48 full hours ago to be pruned.
+		`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			bindFlags(cmd, v)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug("starting prune")
+			retention := v.GetString("retention")
+			targetURLs := v.GetStringSlice("target")
+			var (
+				targets []storage.Storage
+				err     error
+			)
+
+			if len(targetURLs) > 0 {
+				for _, t := range targetURLs {
+					store, err := storage.ParseURL(t, cmdConfig.creds)
+					if err != nil {
+						return fmt.Errorf("invalid target url: %v", err)
+					}
+					targets = append(targets, store)
+				}
+			} else {
+				// try the config file
+				if cmdConfig.configuration != nil {
+					// parse the target objects, then the ones listed for the backup
+					targetStructures := cmdConfig.configuration.Targets
+					dumpTargets := cmdConfig.configuration.Dump.Targets
+					for _, t := range dumpTargets {
+						var store storage.Storage
+						if target, ok := targetStructures[t]; !ok {
+							return fmt.Errorf("target %s from dump configuration not found in targets configuration", t)
+						} else {
+							store, err = target.Storage.Storage()
+							if err != nil {
+								return fmt.Errorf("target %s from dump configuration has invalid URL: %v", t, err)
+							}
+						}
+						targets = append(targets, store)
+					}
+				}
+			}
+
+			if retention == "" && cmdConfig.configuration != nil {
+				retention = cmdConfig.configuration.Prune.Retention
+			}
+
+			// timer options
+			once := v.GetBool("once")
+			if !v.IsSet("once") && cmdConfig.configuration != nil {
+				once = cmdConfig.configuration.Dump.Schedule.Once
+			}
+			cron := v.GetString("cron")
+			if cron == "" && cmdConfig.configuration != nil {
+				cron = cmdConfig.configuration.Dump.Schedule.Cron
+			}
+			begin := v.GetString("begin")
+			if begin == "" && cmdConfig.configuration != nil {
+				begin = cmdConfig.configuration.Dump.Schedule.Begin
+			}
+			frequency := v.GetInt("frequency")
+			if frequency == 0 && cmdConfig.configuration != nil {
+				frequency = cmdConfig.configuration.Dump.Schedule.Frequency
+			}
+			timerOpts := core.TimerOptions{
+				Once:      once,
+				Cron:      cron,
+				Begin:     begin,
+				Frequency: frequency,
+			}
+
+			prune := core.Prune
+			timer := core.TimerCommand
+			if execs != nil {
+				prune = execs.prune
+				timer = execs.timer
+			}
+			if err := timer(timerOpts, func() error {
+				return prune(core.PruneOptions{Targets: targets, Retention: retention})
+			}); err != nil {
+				return fmt.Errorf("error running prune: %w", err)
+			}
+			log.Info("Pruning complete")
+			return nil
+		},
+	}
+	// target - where the backup is
+	v = viper.New()
+	v.SetEnvPrefix("db_restore")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	flags := cmd.Flags()
+	flags.String("target", "", "full URL target to the directory where the backups are stored. Can be a file URL, or a reference to a target in the configuration file, e.g. `config://targetname`.")
+
+	// retention
+	flags.String("retention", "", "Retention period for backups. REQUIRED. Can be number of backups or time-based. For time-based, the format is: 1d, 1w, 1m, 1y for days, weeks, months, years, respectively. For number-based, the format is: 1c, 2c, 3c, etc. for the count of backups to keep.")
+
+	// frequency
+	flags.Int("frequency", defaultFrequency, "how often to run prunes, in minutes")
+
+	// begin
+	flags.String("begin", defaultBegin, "What time to do the first prune. Must be in one of two formats: Absolute: HHMM, e.g. `2330` or `0415`; or Relative: +MM, i.e. how many minutes after starting the container, e.g. `+0` (immediate), `+10` (in 10 minutes), or `+90` in an hour and a half")
+
+	// cron
+	flags.String("cron", "", "Set the prune schedule using standard [crontab syntax](https://en.wikipedia.org/wiki/Cron), a single line.")
+
+	// once
+	flags.Bool("once", false, "Override all other settings and run the prune once immediately and exit. Useful if you use an external scheduler (e.g. as part of an orchestration solution like Cattle or Docker Swarm or [kubernetes cron jobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)) and don't want the container to do the scheduling internally.")
+
+	return cmd, nil
+}

--- a/cmd/prune_test.go
+++ b/cmd/prune_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/databacker/mysql-backup/pkg/core"
+	"github.com/databacker/mysql-backup/pkg/storage"
+	"github.com/databacker/mysql-backup/pkg/storage/file"
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestPruneCmd(t *testing.T) {
+	t.Parallel()
+	fileTarget := "file:///foo/bar"
+	fileTargetURL, _ := url.Parse(fileTarget)
+
+	tests := []struct {
+		name                 string
+		args                 []string // "dump" will be prepended automatically
+		config               string
+		wantErr              bool
+		expectedPruneOptions core.PruneOptions
+		expectedTimerOptions core.TimerOptions
+	}{
+		{"invalid target URL", []string{"--target", "def"}, "", true, core.PruneOptions{}, core.TimerOptions{}},
+		{"file URL", []string{"--target", fileTarget, "--retention", "1h"}, "", false, core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}},
+		{"config file", []string{"--config-file", "testdata/config.yml"}, "", false, core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMockExecs()
+			m.On("prune", mock.MatchedBy(func(pruneOpts core.PruneOptions) bool {
+				diff := deep.Equal(pruneOpts, tt.expectedPruneOptions)
+				if diff == nil {
+					return true
+				}
+				t.Errorf("pruneOpts compare failed: %v", diff)
+				return false
+			})).Return(nil)
+			m.On("timer", tt.expectedTimerOptions).Return(nil)
+			cmd, err := rootCmd(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd.SetArgs(append([]string{"prune"}, tt.args...))
+			err = cmd.Execute()
+			switch {
+			case err == nil && tt.wantErr:
+				t.Fatal("missing error")
+			case err != nil && !tt.wantErr:
+				t.Fatal(err)
+			case err == nil:
+				m.AssertExpectations(t)
+			}
+		})
+	}
+}

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -30,7 +30,7 @@ func TestRestoreCmd(t *testing.T) {
 		{"missing server and target options", []string{""}, "", true, nil, "", database.Connection{}, nil, &compression.GzipCompressor{}},
 		{"invalid target URL", []string{"--server", "abc", "--target", "def"}, "", true, nil, "", database.Connection{Host: "abc"}, nil, &compression.GzipCompressor{}},
 		{"valid URL missing dump filename", []string{"--server", "abc", "--target", "file:///foo/bar"}, "", true, nil, "", database.Connection{Host: "abc"}, nil, &compression.GzipCompressor{}},
-		{"valid file URL", []string{"--server", "abc", "--target", fileTarget, "filename.tgz"}, "", false, file.New(*fileTargetURL), "filename.tgz", database.Connection{Host: "abc"}, map[string]string{}, &compression.GzipCompressor{}},
+		{"valid file URL", []string{"--server", "abc", "--target", fileTarget, "filename.tgz", "--verbose", "2"}, "", false, file.New(*fileTargetURL), "filename.tgz", database.Connection{Host: "abc"}, map[string]string{}, &compression.GzipCompressor{}},
 	}
 
 	for _, tt := range tests {
@@ -50,7 +50,6 @@ func TestRestoreCmd(t *testing.T) {
 				t.Fatal(err)
 			case err == nil:
 				m.AssertExpectations(t)
-				//m.AssertCalled(t, "restore", tt.expectedTarget, tt.expectedTargetFile, tt.expectedDbconn, tt.expectedDatabasesMap, tt.expectedCompressor)
 			}
 
 		})

--- a/cmd/testdata/config.yml
+++ b/cmd/testdata/config.yml
@@ -1,9 +1,9 @@
 database:
-  server: abc
+  server: abcd
   port: 3306
   credentials:
-    username: user
-    password: xxxx
+    username: user2
+    password: xxxx2
 
 targets:
   local:
@@ -16,3 +16,6 @@ targets:
 dump:
   targets:
   - local
+
+prune:
+  retention: "1h"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ Various sample configuration files are available in the [sample-configs](../samp
 
 ## Configuration Options
 
-The following are the environment variables, CLI flags and configuration file options for a backup or a restore.
+The following are the environment variables, CLI flags and configuration file options for: backup(B), restore (R), prune (P).
 
 | Purpose | Backup / Restore | CLI Flag | Env Var | Config Key | Default |
 | --- | --- | --- | --- | --- | --- |
@@ -70,21 +70,21 @@ The following are the environment variables, CLI flags and configuration file op
 | names of databases to exclude from the dump | B | `exclude` | `DB_NAMES_EXCLUDE` | `database.exclude` |  |
 | do not include `USE <database>;` statement in the dump | B | `no-database-name` | `NO_DATABASE_NAME` | `database.no-database-name` | `false` |
 | restore to a specific database | R | `restore --database` | `RESTORE_DATABASE` | `restore.database` |  |
-| how often to do a dump, in minutes | B | `dump --frequency` | `DB_DUMP_FREQ` | `dump.schedule.frequency` | `1440` (in minutes), i.e. once per day |
-| what time to do the first dump | B | `dump --begin` | `DB_DUMP_BEGIN` | `dump.schedule.begin` | `0`, i.e. immediately |
-| cron schedule for dumps | B | `dump --cron` | `DB_DUMP_CRON` | `dump.schedule.cron` |  |
-| run the backup a single time and exit | B | `dump --once` | `RUN_ONCE` | `dump.schedule.once` | `false` |
-| enable debug logging | BR | `debug` | `DEBUG` | `logging: debug` | `false` |
-| where to put the dump file; see [backup](./backup.md) | B | `dump --target` | `DB_DUMP_TARGET` | `dump.targets` |  |
+| how often to do a dump or prune, in minutes | BP | `dump --frequency` | `DB_DUMP_FREQ` | `dump.schedule.frequency` | `1440` (in minutes), i.e. once per day |
+| what time to do the first dump or prune | BP | `dump --begin` | `DB_DUMP_BEGIN` | `dump.schedule.begin` | `0`, i.e. immediately |
+| cron schedule for dumps or prunes | BP | `dump --cron` | `DB_DUMP_CRON` | `dump.schedule.cron` |  |
+| run the backup or prune a single time and exit | BP | `dump --once` | `RUN_ONCE` | `dump.schedule.once` | `false` |
+| enable debug logging | BRP | `debug` | `DEBUG` | `logging: debug` | `false` |
+| where to put the dump file; see [backup](./backup.md) | BP | `dump --target` | `DB_DUMP_TARGET` | `dump.targets` |  |
 | where the restore file exists; see [restore](./restore.md) | R | `restore --target` | `DB_RESTORE_TARGET` | `restore.target` |  |
-| replace any `:` in the dump filename with `-` | B | `dump --safechars` | `DB_DUMP_SAFECHARS` | `database.safechars` | `false` |
-| AWS access key ID, used only if a target does not have one | BR | `aws-access-key-id` | `AWS_ACCESS_KEY_ID` | `dump.targets[s3-target].credentials.access-key-id` |  |
-| AWS secret access key, used only if a target does not have one | BR | `aws-secret-access-key` | `AWS_SECRET_ACCESS_KEY` | `dump.targets[s3-target].credentials.secret-access-key` |  |
-| AWS default region, used only if a target does not have one | BR | `aws-region` | `AWS_REGION` | `dump.targets[s3-target].region` |  |
+| replace any `:` in the dump filename with `-` | BP | `dump --safechars` | `DB_DUMP_SAFECHARS` | `database.safechars` | `false` |
+| AWS access key ID, used only if a target does not have one | BRP | `aws-access-key-id` | `AWS_ACCESS_KEY_ID` | `dump.targets[s3-target].credentials.access-key-id` |  |
+| AWS secret access key, used only if a target does not have one | BRP | `aws-secret-access-key` | `AWS_SECRET_ACCESS_KEY` | `dump.targets[s3-target].credentials.secret-access-key` |  |
+| AWS default region, used only if a target does not have one | BRP | `aws-region` | `AWS_REGION` | `dump.targets[s3-target].region` |  |
 | alternative endpoint URL for S3-interoperable systems, used only if a target does not have one | BR | `aws-endpoint-url` | `AWS_ENDPOINT_URL` | `dump.targets[s3-target].endpoint` |  |
-| SMB username, used only if a target does not have one | BR | `smb-user` | `SMB_USER` | `dump.targets[smb-target].credentials.username` |  |
-| SMB password, used only if a target does not have one | BR | `smb-pass` | `SMB_PASS` | `dump.targets[smb-target].credentials.password` |  |
-| compression to use, one of: `bzip2`, `gzip` | B | `compression` | `COMPRESSION` | `dump.compression` | `gzip` |
+| SMB username, used only if a target does not have one | BRP | `smb-user` | `SMB_USER` | `dump.targets[smb-target].credentials.username` |  |
+| SMB password, used only if a target does not have one | BRP | `smb-pass` | `SMB_PASS` | `dump.targets[smb-target].credentials.password` |  |
+| compression to use, one of: `bzip2`, `gzip` | BP | `compression` | `COMPRESSION` | `dump.compression` | `gzip` |
 | when in container, run the dump or restore with `nice`/`ionice` | BR | `` | `NICE` | `` | `false` |
 | tmp directory to be used during backup creation and other operations | BR | `tmp` | `TMP_PATH` | `tmp` | system-defined |
 | filename to save the target backup file | B | `dump --filename-pattern` | `DB_DUMP_FILENAME_PATTERN` | `dump.filename-pattern` |  |
@@ -92,12 +92,4 @@ The following are the environment variables, CLI flags and configuration file op
 | directory with scripts to execute after backup | B | `dump --post-backup-scripts` | `DB_DUMP_POST_BACKUP_SCRIPTS` | `dump.scripts.post-backup` | in container, `/scripts.d/post-backup/` |
 | directory with scripts to execute before restore | R | `restore --pre-restore-scripts` | `DB_DUMP_PRE_RESTORE_SCRIPTS` | `dump.pre-restore-scripts` | in container, `/scripts.d/pre-restore/` |
 | directory with scripts to execute after restore | R | `restore --post-restore-scripts` | `DB_DUMP_POST_RESTORE_SCRIPTS` | `dump.post-restore-scripts` | in container, `/scripts.d/post-restore/` |
-
-
-## Unsupported Options
-
-Unsupported options from the old version of `mysql-backup`:
-
-* `MYSQLDUMP_OPTS`: A string of options to pass to `mysqldump`, e.g. `MYSQLDUMP_OPTS="--opt abc --param def --max_allowed_packet=123455678"` will run `mysqldump --opt abc --param def --max_allowed_packet=123455678`. These are replaced by individual options.
-* `AWS_CLI_OPTS`: Additional arguments to be passed to the `aws` part of the `aws s3 cp` command, click [here](https://docs.aws.amazon.com/cli/latest/reference/#options) for a list. These are replaced by target-specific options.
-* `AWS_CLI_S3_CP_OPTS`: Additional arguments to be passed to the `s3 cp` part of the `aws s3 cp` command, click [here](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html#options) for a list. If you are using AWS KMS, `sse`, `sse-kms-key-id`, etc., may be of interest. These are replaced by target-specific options
+| retention policy for backups | BP | `dump --retention` | `RETENTION` | `prune.retention` | Infinite |

--- a/docs/prune.md
+++ b/docs/prune.md
@@ -1,0 +1,63 @@
+# Pruning
+
+Pruning is the process of removing backups that no longer are needed.
+
+mysql-backup does **not** do this by default; it is up to you to enable this feature, if you want it.
+
+## Launching Pruning
+
+Pruning happens only in the following scenarios:
+
+* During pruning runs
+* During backup runs
+
+It does not occur during restore runs.
+
+### Pruning Runs
+
+You can start `mysql-backup` with the command `prune` to run a pruning operation. It will prune any backups that are no longer needed.
+
+Like backups, it can run once and then exit, or it can run on a schedule.
+
+It uses the same configuration options for scheduling as backups, see the [scheduling](./scheduling.md) documentation for more information,
+specifically the section about [Scheduling Options](./scheduling.md#scheduling-options).
+
+### Backup Runs
+
+When running `mysql-backup` in backup mode, it _optionally_ can also prune older backups before each backup run.
+When enabled, it will prune any backups that fit the pruning criteria.
+
+## Pruning Criteria
+
+Pruning can be on the basis of the _age_ of a specific backup, or the _number_ of backups. Both are set by the configuration setting:
+
+* Environment variable: `RETENTION=<value>`
+* CLI flag: `dump --retention=<value>` or `prune --retention=<value>`
+* Config file:
+```yaml
+prune:
+    retention: <value>
+```
+
+The value of retention always is an integer followed by a letter. The letter can one of:
+
+* `h` - hours, e.g. `2h`
+* `d` - days, e.g. `3d`
+* `w` - weeks, e.g. `4w`
+* `m` - months, e.g. `3m`
+* `y` - years, e.g. `5y`
+* `c` - count, how many backup to keep, e.g. `10c`; this could have been simply `10`, but was kept as `c` to avoid accidental confusion with the other options.
+
+Most of these are interchangeable, e.g. `3d` is the same as `72h`, and `4w` is the same as `28d` is the same as `672h`.
+
+When calculating whether or not to prune, `mysql-backup` __always__ converts the amount to hours, and then errs on the side of caution.
+For example, if provided `7d`, it will convert that to `168h`, and then prune any backups older than 168 full hours. If it is 167 hours and 59 minutes old, it
+will not be pruned.
+
+## Determining backup age
+
+Pruning depends on the name of the backup file, rather than the timestamp on the target filesystem, as the latter can be unreliable.
+This means that the filename must be of a known pattern.
+
+As of this writing, pruning only work for backup files whose filename uses the default naming scheme, as described in
+["Dump File" in backup documentation](./backup.md#dump-file). We hope to support custom filenames in the future.

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -34,6 +34,7 @@ type Config struct {
 	Restore  Restore  `yaml:"restore"`
 	Database Database `yaml:"database"`
 	Targets  Targets  `yaml:"targets"`
+	Prune    Prune    `yaml:"prune"`
 }
 
 type Dump struct {
@@ -49,6 +50,10 @@ type Dump struct {
 	FilenamePattern  string        `yaml:"filename-pattern"`
 	Scripts          BackupScripts `yaml:"scripts"`
 	Targets          []string      `yaml:"targets"`
+}
+
+type Prune struct {
+	Retention string `yaml:"retention"`
 }
 
 type Schedule struct {

--- a/pkg/core/dump.go
+++ b/pkg/core/dump.go
@@ -19,25 +19,6 @@ const (
 	targetRenameCmd = "/scripts.d/target.sh"
 )
 
-// TimerDump runs a dump on a timer
-func TimerDump(opts DumpOptions, timerOpts TimerOptions) error {
-	c, err := Timer(timerOpts)
-	if err != nil {
-		log.Errorf("error creating timer: %v", err)
-		os.Exit(1)
-	}
-	// block and wait for it
-	for update := range c {
-		if err := Dump(opts); err != nil {
-			return fmt.Errorf("error backing up: %w", err)
-		}
-		if update.Last {
-			break
-		}
-	}
-	return nil
-}
-
 // Dump run a single dump, based on the provided opts
 func Dump(opts DumpOptions) error {
 	targets := opts.Targets

--- a/pkg/core/prune.go
+++ b/pkg/core/prune.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// filenameRE is a regular expression to match a backup filename
+var filenameRE = regexp.MustCompile(`^db_backup_(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z\.\w+$`)
+
+// Prune prune older backups
+func Prune(opts PruneOptions) error {
+	log.Info("beginning prune")
+	var (
+		candidates []string
+		now        = opts.Now
+	)
+	if now.IsZero() {
+		now = time.Now()
+	}
+	retainHours, err1 := convertToHours(opts.Retention)
+	retainCount, err2 := convertToCount(opts.Retention)
+	if err1 != nil && err2 != nil {
+		return fmt.Errorf("invalid retention string: %s", opts.Retention)
+	}
+	if len(opts.Targets) == 0 {
+		return errors.New("no targets")
+	}
+
+	for _, target := range opts.Targets {
+		var pruned int
+
+		log.Debugf("pruning target %s", target)
+		files, err := target.ReadDir(".")
+		if err != nil {
+			return fmt.Errorf("failed to read directory: %v", err)
+		}
+
+		// create a slice with the filenames and their calculated times - these are *not* the timestamp times, but the times calculated from the filenames
+		var filesWithTimes []fileWithTime
+
+		for _, fileInfo := range files {
+			filename := fileInfo.Name()
+			matches := filenameRE.FindStringSubmatch(filename)
+			if matches == nil {
+				log.Debugf("ignoring filename that is not standard backup pattern: %s", filename)
+				continue
+			}
+			log.Debugf("checking filename that is standard backup pattern: %s", filename)
+
+			// Parse the date from the filename
+			year, month, day, hour, minute, second := matches[1], matches[2], matches[3], matches[4], matches[5], matches[6]
+			dateTimeStr := fmt.Sprintf("%s-%s-%sT%s:%s:%sZ", year, month, day, hour, minute, second)
+			filetime, err := time.Parse(time.RFC3339, dateTimeStr)
+			if err != nil {
+				log.Debugf("Error parsing date from filename %s: %v; ignoring", filename, err)
+				continue
+			}
+			filesWithTimes = append(filesWithTimes, fileWithTime{
+				filename: filename,
+				filetime: filetime,
+			})
+		}
+
+		switch {
+		case retainHours > 0:
+			// if we had retainHours, we go through all of the files and find any whose timestamp is older than now-retainHours
+			for _, f := range filesWithTimes {
+				// Check if the file is within 'retain' hours from 'now'
+				age := now.Sub(f.filetime).Hours()
+				if age < float64(retainHours) {
+					log.Debugf("file %s is %f hours old", f.filename, age)
+					log.Debugf("keeping file %s", f.filename)
+					continue
+				}
+				log.Debugf("Adding candidate file: %s", f.filename)
+				candidates = append(candidates, f.filename)
+			}
+		case retainCount > 0:
+			// if we had retainCount, we sort all of the files by timestamp, and add to the list all except the retainCount most recent
+			slices.SortFunc(filesWithTimes, func(i, j fileWithTime) int {
+				switch {
+				case i.filetime.Before(j.filetime):
+					return -1
+				case i.filetime.After(j.filetime):
+					return 1
+				}
+				return 0
+			})
+			slices.Reverse(filesWithTimes)
+			if retainCount >= len(filesWithTimes) {
+				for i := 0 + retainCount; i < len(filesWithTimes); i++ {
+					log.Debugf("Adding candidate file %s:", filesWithTimes[i].filename)
+					candidates = append(candidates, filesWithTimes[i].filename)
+				}
+			}
+		default:
+			return fmt.Errorf("invalid retention string: %s", opts.Retention)
+		}
+
+		// we have the list, remove them all
+		for _, filename := range candidates {
+			if err := target.Remove(filename); err != nil {
+				return fmt.Errorf("failed to remove file %s: %v", filename, err)
+			}
+			pruned++
+		}
+		log.Debugf("pruning %d files from target %s", pruned, target)
+	}
+
+	return nil
+}
+
+// convertToHours takes a string with format "<integer><unit>" and converts it to hours.
+// The unit can be 'h' (hours), 'd' (days), 'w' (weeks), 'm' (months), 'y' (years).
+// Assumes 30 days in a month and 365 days in a year for conversion.
+func convertToHours(input string) (int, error) {
+	re := regexp.MustCompile(`^(\d+)([hdwmy])$`)
+	matches := re.FindStringSubmatch(input)
+
+	if matches == nil {
+		return 0, fmt.Errorf("invalid format: %s", input)
+	}
+
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid number: %s", matches[1])
+	}
+
+	unit := matches[2]
+	switch unit {
+	case "h":
+		return value, nil
+	case "d":
+		return value * 24, nil
+	case "w":
+		return value * 24 * 7, nil
+	case "m":
+		return value * 24 * 30, nil // Approximation
+	case "y":
+		return value * 24 * 365, nil // Approximation
+	default:
+		return 0, errors.New("invalid unit")
+	}
+}
+
+// convertToCount takes a string with format "<integer><unit>" and converts it to count.
+// The unit can be 'c' (count)
+func convertToCount(input string) (int, error) {
+	re := regexp.MustCompile(`^(\d+)([c])$`)
+	matches := re.FindStringSubmatch(input)
+
+	if matches == nil {
+		return 0, fmt.Errorf("invalid format: %s", input)
+	}
+
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid number: %s", matches[1])
+	}
+
+	unit := matches[2]
+	switch unit {
+	case "c":
+		return value, nil
+	default:
+		return 0, errors.New("invalid unit")
+	}
+}
+
+type fileWithTime struct {
+	filename string
+	filetime time.Time
+}

--- a/pkg/core/prune_test.go
+++ b/pkg/core/prune_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/databacker/mysql-backup/pkg/storage"
+	"github.com/databacker/mysql-backup/pkg/storage/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertToHours(t *testing.T) {
+	tests := []struct {
+		input  string
+		output int
+		err    error
+	}{
+		{"2h", 2, nil},
+		{"3w", 3 * 7 * 24, nil},
+		{"5d", 5 * 24, nil},
+		{"1m", 30 * 24, nil},
+		{"1y", 365 * 24, nil},
+		{"100x", 0, fmt.Errorf("invalid format: 100x")},
+	}
+	for _, tt := range tests {
+		hours, err := convertToHours(tt.input)
+		switch {
+		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil):
+			t.Errorf("expected error %v, got %v", tt.err, err)
+		case err != nil && tt.err != nil && err.Error() != tt.err.Error():
+			t.Errorf("expected error %v, got %v", tt.err, err)
+		case hours != tt.output:
+			t.Errorf("input %s expected %d, got %d", tt.input, tt.output, hours)
+		}
+	}
+}
+
+func TestPrune(t *testing.T) {
+	// we use a fixed list of file before, and a subset of them for after
+	// db_backup_YYYY-MM-DDTHH:mm:ssZ.<compression>
+	// our list of timestamps should give us these files, of the following time ago:
+	// 0.25h, 1h, 2h, 3h, 24h (1d), 36h (1.5d), 48h (2d), 60h (2.5d) 72h(3d),
+	// 167h (1w-1h), 168h (1w), 240h (1.5w) 336h (2w), 576h (2.5w), 504h (3w)
+	// 744h (3.5w), 720h (1m), 1000h (1.5m), 1440h (2m), 1800h (2.5m), 2160h (3m),
+	// 8760h (1y), 12000h (1.5y), 17520h (2y)
+	// we use a fixed starting time to make it consistent.
+	now := time.Date(2021, 1, 1, 0, 30, 0, 0, time.UTC)
+	hoursAgo := []float32{0.25, 1, 2, 3, 24, 36, 48, 60, 72, 167, 168, 240, 336, 504, 576, 744, 720, 1000, 1440, 1800, 2160, 8760, 12000, 17520}
+	// convert to filenames
+	var filenames []string
+	for _, h := range hoursAgo {
+		// convert the time diff into a duration, do not forget the negative
+		duration, err := time.ParseDuration(fmt.Sprintf("-%fh", h))
+		if err != nil {
+			t.Fatalf("failed to parse duration: %v", err)
+		}
+		// convert it into a time.Time
+		// and add 30 mins to our "now" time.
+		relativeTime := now.Add(duration).Add(-30 * time.Minute)
+		// convert that into the filename
+		filename := fmt.Sprintf("db_backup_%sZ.gz", relativeTime.Format("2006-01-02T15:04:05"))
+		filenames = append(filenames, filename)
+	}
+	tests := []struct {
+		name        string
+		opts        PruneOptions
+		beforeFiles []string
+		afterFiles  []string
+		err         error
+	}{
+		{"invalid format", PruneOptions{Retention: "100x", Now: now}, nil, nil, fmt.Errorf("invalid retention string: 100x")},
+		{"no targets", PruneOptions{Retention: "1h", Now: now}, nil, nil, fmt.Errorf("no targets")},
+		// 1 hour - file[1] is 1h+30m = 1.5h, so it should be pruned
+		{"1 hour", PruneOptions{Retention: "1h", Now: now}, filenames, filenames[0:1], nil},
+		// 2 hours - file[2] is 2h+30m = 2.5h, so it should be pruned
+		{"2 hours", PruneOptions{Retention: "2h", Now: now}, filenames, filenames[0:2], nil},
+		// 2 days - file[6] is 48h+30m = 48.5h, so it should be pruned
+		{"2 days", PruneOptions{Retention: "2d", Now: now}, filenames, filenames[0:6], nil},
+		// 3 weeks - file[13] is 504h+30m = 504.5h, so it should be pruned
+		{"3 weeks", PruneOptions{Retention: "3w", Now: now}, filenames, filenames[0:13], nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create a temporary directory
+			workDir := t.TempDir()
+			// create beforeFiles in the directory and create a target, but only if there are beforeFiles
+			// this lets us also test no targets, which should generate an error
+			if len(tt.beforeFiles) > 0 {
+				for _, filename := range tt.beforeFiles {
+					if err := os.WriteFile(fmt.Sprintf("%s/%s", workDir, filename), nil, 0644); err != nil {
+						t.Errorf("failed to create file %s: %v", filename, err)
+						return
+					}
+				}
+
+				// add our tempdir as the target
+				store, err := storage.ParseURL(fmt.Sprintf("file://%s", workDir), credentials.Creds{})
+				if err != nil {
+					t.Errorf("failed to parse url: %v", err)
+					return
+				}
+
+				tt.opts.Targets = append(tt.opts.Targets, store)
+			}
+
+			// run Prune
+			err := Prune(tt.opts)
+			switch {
+			case (err == nil && tt.err != nil) || (err != nil && tt.err == nil):
+				t.Errorf("expected error %v, got %v", tt.err, err)
+			case err != nil && tt.err != nil && err.Error() != tt.err.Error():
+				t.Errorf("expected error %v, got %v", tt.err, err)
+			}
+			// check files match
+			files, err := os.ReadDir(workDir)
+			if err != nil {
+				t.Errorf("failed to read directory: %v", err)
+				return
+			}
+			var afterFiles []string
+			for _, file := range files {
+				afterFiles = append(afterFiles, file.Name())
+			}
+			slices.Sort(afterFiles)
+			slices.Sort(tt.afterFiles)
+			assert.ElementsMatch(t, tt.afterFiles, afterFiles)
+		})
+	}
+}

--- a/pkg/core/pruneoptions.go
+++ b/pkg/core/pruneoptions.go
@@ -1,0 +1,13 @@
+package core
+
+import (
+	"time"
+
+	"github.com/databacker/mysql-backup/pkg/storage"
+)
+
+type PruneOptions struct {
+	Targets   []storage.Storage
+	Retention string
+	Now       time.Time
+}

--- a/pkg/storage/file/file.go
+++ b/pkg/storage/file/file.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path"
@@ -31,6 +32,27 @@ func (f *File) Protocol() string {
 
 func (f *File) URL() string {
 	return f.url.String()
+}
+
+func (f *File) ReadDir(dirname string) ([]fs.FileInfo, error) {
+
+	entries, err := os.ReadDir(filepath.Join(f.path, dirname))
+	if err != nil {
+		return nil, err
+	}
+	var files []fs.FileInfo
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, info)
+	}
+	return files, nil
+}
+
+func (f *File) Remove(target string) error {
+	return os.Remove(filepath.Join(f.path, target))
 }
 
 // copyFile copy a file from to as efficiently as possible

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,8 +1,13 @@
 package storage
 
+import "io/fs"
+
 type Storage interface {
 	Push(target, source string) (int64, error)
 	Pull(source, target string) (int64, error)
 	Protocol() string
 	URL() string
+	ReadDir(dirname string) ([]fs.FileInfo, error)
+	// Remove remove a particular file
+	Remove(string) error
 }

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -442,7 +442,9 @@ func runDumpTest(dc *dockerContext, compact bool, base string, targets []backupT
 	timerOpts := core.TimerOptions{
 		Once: true,
 	}
-	return core.TimerDump(dumpOpts, timerOpts)
+	return core.TimerCommand(timerOpts, func() error {
+		return core.Dump(dumpOpts)
+	})
 }
 
 func setup(dc *dockerContext, base, backupFile, compactBackupFile string) (mysql, smb containerPort, s3url string, s3backend gofakes3.Backend, err error) {


### PR DESCRIPTION
Fixes #274 

Create retention option for `dump`, where it goes through older backups and delete any that are outside the retention window.

This is enabled in 2 scenarios via the `RETENTION` env var / `--retention` flag / `prune.retention` config file option:

* during backups
* with a new `mysql-backup prune` command

A new `docs/prune.md` page has been created, and the option has been added to `docs/configuration.md`

Currently draft as it only includes the docs.