### PR TITLE
fix: Cron consecutive runs

### DIFF
--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -40,16 +40,17 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 		err   error
 	)
 
-	now := time.Now().UTC()
 	// parse the options to determine our delays
 	if opts.Cron != "" {
 		// calculate delay until next cron moment as defined
+		now := time.Now().UTC()
 		delay, err = waitForCron(opts.Cron, now)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cron format '%s': %v", opts.Cron, err)
 		}
 	} else if opts.Begin != "" {
 		// calculate delay based on begin time
+		now := time.Now().UTC()
 		delay, err = waitForBeginTime(opts.Begin, now)
 		if err != nil {
 			return nil, fmt.Errorf("invalid begin option '%s': %v", opts.Begin, err)
@@ -72,19 +73,20 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 
 		// create our delay and timer loop and go
 		for {
-			lastRun := time.Now()
+			lastRun := time.Now().UTC()
 
 			// not once - run the first backup
 			sendTimer(c, false)
 
 			if opts.Cron != "" {
+				now := time.Now().UTC()
 				delay, _ = waitForCron(opts.Cron, now)
 			} else {
 				// calculate how long until the next run
 				// just take our last start time, and add the frequency until it is past our
 				// current time. We cannot just take the last time and add,
 				// because it might have been during a backup run
-				now := time.Now()
+				now := time.Now().UTC()
 				diff := int(now.Sub(lastRun).Minutes())
 				// make sure we at least wait one full frequency
 				if diff == 0 {


### PR DESCRIPTION
Closes #278 
Cron delay is always calculated relative to startup time, so its correct on the first run and wrong afterward.

I have no good way of adding a test for this, without restructuring it or injecting a dummy sleep function.