### PR TITLE
Support connecting with a unix domain socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ docker run -d --restart=always -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=2330 -e DB_DU
 # or
 
 mysql-backup dump --frequency=60 --begin=2330 --target=/local/file/path --server=my-db-address
+
+# or to connect to a local mysqld via the unix domain socket as the current user
+
+mysql-backup dump --frequency=60 --begin=2330 --target=/local/file/path --server=/run/mysqld/mysqld.sock
 ````
 
 Or `mysql-backup --config-file=/path/to/config/file.yaml` where `/path/to/config/file.yaml` is a file
@@ -87,7 +91,7 @@ You need only the following environment variables:
 
 __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables-e-env-env-file) to keep your secrets out of your shell history__
 
-* `DB_SERVER`: hostname to connect to database. Required.
+* `DB_SERVER`: hostname or unix domain socket path (starting with a slash) to connect to database. Required.
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ The following are the environment variables, CLI flags and configuration file op
 
 | Purpose | Backup / Restore | CLI Flag | Env Var | Config Key | Default |
 | --- | --- | --- | --- | --- | --- |
-| hostname to connect to database. Required. | BR | `server` | `DB_SERVER` | `database.server` |  |
+| hostname or unix domain socket path (starting with a slash) to connect to database. Required. | BR | `server` | `DB_SERVER` | `database.server` |  |
 | port to use to connect to database. Optional. | BR | `port` | `DB_PORT` | `database.port` | 3306 |
 | username for the database | BR | `user` | `DB_USER` | `database.credentials.username` |  |
 | password for the database | BR | `pass` | `DB_PASS` | `database.credentials.password` |  |

--- a/docs/database_address.md
+++ b/docs/database_address.md
@@ -9,7 +9,7 @@ In order to perform the actual dump or restore, `mysql-backup` needs to connect 
 db-server: my-db-address
 ```
 
-The address itself, in the above example `my-db-address`, can be a container or any database process, as long as it is
+The address itself, in the above example `my-db-address`, can be a hostname, ip address, or path to a unix domain socket , as long as it is
 accessible from where the `mysql-backup` runs.
 
 The default port is `3306`, the normal default port for mysql. You can override the default port of `3306` via

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"fmt"
+	"strings"
 
 	mysql "github.com/go-sql-driver/mysql"
 )
@@ -17,8 +18,13 @@ func (c Connection) MySQL() string {
 	config := mysql.NewConfig()
 	config.User = c.User
 	config.Passwd = c.Pass
-	config.Net = "tcp"
-	config.Addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
+	if strings.HasPrefix(c.Host, "/") {
+		config.Net = "unix"
+		config.Addr = c.Host
+	} else {
+		config.Net = "tcp"
+		config.Addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
+	}
 	config.ParseTime = true
 	return config.FormatDSN()
 }

--- a/pkg/database/schemas.go
+++ b/pkg/database/schemas.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 func GetSchemas(dbconn Connection) ([]string, error) {
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/", dbconn.User, dbconn.Pass, dbconn.Host, dbconn.Port))
+	db, err := sql.Open("mysql", dbconn.MySQL())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection to database: %v", err)
 	}


### PR DESCRIPTION
As discussed in  #285

This changes the semantics of `--server` (or the env var, etc) to `--server <IP/FQDN | /path/to/socket>`