### PR TITLE
when in tests, send cobra help and errors to discard

### DIFF
--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"net/url"
 	"testing"
 
@@ -140,6 +141,7 @@ func TestDumpCmd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(append([]string{"dump"}, tt.args...))
 			err = cmd.Execute()
 			switch {

--- a/cmd/prune_test.go
+++ b/cmd/prune_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"net/url"
 	"testing"
 
@@ -43,6 +44,7 @@ func TestPruneCmd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(append([]string{"prune"}, tt.args...))
 			err = cmd.Execute()
 			switch {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"net/url"
 	"testing"
 
@@ -49,6 +50,7 @@ func TestRestoreCmd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(append([]string{"restore"}, tt.args...))
 			err = cmd.Execute()
 			switch {


### PR DESCRIPTION
The output was making it hard to see the actual error messages for failed tests, and didn't add anything.