### PR TITLE
switch once env var to fit with others

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ The following are the environment variables, CLI flags and configuration file op
 | how often to do a dump or prune, in minutes | BP | `dump --frequency` | `DB_DUMP_FREQ` | `dump.schedule.frequency` | `1440` (in minutes), i.e. once per day |
 | what time to do the first dump or prune | BP | `dump --begin` | `DB_DUMP_BEGIN` | `dump.schedule.begin` | `0`, i.e. immediately |
 | cron schedule for dumps or prunes | BP | `dump --cron` | `DB_DUMP_CRON` | `dump.schedule.cron` |  |
-| run the backup or prune a single time and exit | BP | `dump --once` | `RUN_ONCE` | `dump.schedule.once` | `false` |
+| run the backup or prune a single time and exit | BP | `dump --once` | `DB_DUMP_ONCE` | `dump.schedule.once` | `false` |
 | enable debug logging | BRP | `debug` | `DEBUG` | `logging` | `false` |
 | where to put the dump file; see [backup](./backup.md) | BP | `dump --target` | `DB_DUMP_TARGET` | `dump.targets` |  |
 | where the restore file exists; see [restore](./restore.md) | R | `restore --target` | `DB_RESTORE_TARGET` | `restore.target` |  |

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -24,8 +24,8 @@ The scheduling options have an order of priority:
 
 You can set it to run just once via:
 
-* Environment variable: `RUN_ONCE=true`
-* CLI flag: `dump --run-once`
+* Environment variable: `DB_DUMP_ONCE=true`
+* CLI flag: `dump --once`
 * Config file:
 ```yaml
 dump:

--- a/test/test_restore.sh
+++ b/test/test_restore.sh
@@ -53,7 +53,7 @@ docker container create \
 -e DB_SERVER=mysql \
 -e DB_USER=$MYSQLUSER \
 -e DB_PASS=$MYSQLPW \
--e RUN_ONCE=1 \
+-e DB_DUMP_ONCE=1 \
 -e MYSQLDUMP_OPTS="${MYSQLDUMP_OPTS}" \
 ${BACKUP_IMAGE})
 docker container start $cid_dump


### PR DESCRIPTION
The env vars for all dump configuration have the following characteristics:

* start with `DB_DUMP_`
* use the name of the CLI flag after the prefix, converted to upper-case, and with `-` switched to `_`

So `--begin` becomes `DB_DUMP_BEGIN`, etc.

There is one exception to this, `--once` which uses the env var `RUN_ONCE` rather than `DB_DUMP_ONCE`. This causes a lot of headaches, and libraries that do not handle it correctly, etc.

Since 1.0.0 is not yet GA, we are just switching the env var.