### PR TITLE
remove unnecessary and undocumented source.sh and target.sh

### DIFF
--- a/pkg/core/scripts.go
+++ b/pkg/core/scripts.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,22 +34,4 @@ func runScripts(dir string, env map[string]string) error {
 		}
 	}
 	return nil
-}
-
-func oneScript(target string, env map[string]string) ([]byte, error) {
-	// execute the file
-	envSlice := os.Environ()
-	for k, v := range env {
-		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
-	}
-	cmd := exec.Command(target)
-	cmd.Env = envSlice
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("error running file %s: %v", target, err)
-	}
-	return stdout.Bytes(), nil
 }


### PR DESCRIPTION
These were used in the old bash-based version. In the newer version (from `1.0.0-rc*` onwards):

* they were not documented anywhere
* they depended on a hard-coded path to `/scripts.d/`, which only made sense in a container context
* `source.sh` is unneeded as you can use post-backup scripts, which include an example of adding data to the backup file
* `target.sh` is unneeded, as you have the option `--filename-pattern`