### PR TITLE
Fix workflow execution error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,23 +31,15 @@ jobs:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
     - id: fileschanged
       run: |
-        case '${{ github.event_name }}' in
-          push)
-            firstCommit='${{ github.event.commits[0].id }}'
-            lastCommit='${{ github.event.commits[-1].id }}'
-            ;;
-          pull_request)
-            firstCommit='${{ github.event.pull_request.base.sha }}'
-            lastCommit='${{ github.event.pull_request.head.sha }}'
-            ;;
-        esac
+        firstCommit='${{ github.event.before }}'
+        lastCommit='${{ github.event.after }}'
         changedFiles=$(git diff --name-only --diff-filter=d "${firstCommit}" "${lastCommit}")
         echo "Files changed: $changedFiles"
         NON_MD_FILES=$(echo "$changedFiles" | grep -v '\.md$' || true)
         if [ -n "$NON_MD_FILES" ]; then
-          echo "non_doc_files_changed=true" >> $GITHUB_ENV
+          echo "non_doc_files_changed=true" >> $GITHUB_OUTPUT
         else
-          echo "non_doc_files_changed=false" >> $GITHUB_ENV
+          echo "non_doc_files_changed=false" >> $GITHUB_OUTPUT
         fi
   ci:
     name: CI


### PR DESCRIPTION
Fix workflow execution error

Change the GITHUB_ENV to [GITHUB_OUTPUT](https://docs.github.com/zh/actions/writing-workflows/workflow-syntax-for-github-actions#%E5%9C%A8%E7%9F%A9%E9%98%B5%E4%BD%9C%E4%B8%9A%E4%B8%AD%E4%BD%BF%E7%94%A8%E4%BD%9C%E4%B8%9A%E8%BE%93%E5%87%BA)

The obtaining of `firstCommit` and `lastCommit`refers to the following two documents

[pull_request](https://docs.github.com/zh/webhooks/webhook-events-and-payloads#pull_request) [push](https://docs.github.com/zh/webhooks/webhook-events-and-payloads#push)