### PR TITLE
Alpine 3.20 based Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # mysql backup image
-FROM golang:1.21.5-alpine3.19 as build
+FROM golang:1.21.13-alpine3.20 AS build
 
 COPY . /src/mysql-backup
 WORKDIR /src/mysql-backup
@@ -7,17 +7,17 @@ WORKDIR /src/mysql-backup
 RUN mkdir /out && go build -o /out/mysql-backup .
 
 # we would do from scratch, but we need basic utilities in order to support pre/post scripts
-FROM alpine:3.19
+FROM alpine:3.20 AS runtime
 LABEL org.opencontainers.image.authors="https://github.com/databacker"
 
 # set us up to run as non-root user
-RUN apk add bash
-RUN addgroup -g 1005 appuser && \
+RUN apk add --no-cache bash && \
+    addgroup -g 1005 appuser && \
     adduser -u 1005 -G appuser -D appuser
+
 USER appuser
 
 COPY --from=build /out/mysql-backup /mysql-backup
-
 COPY entrypoint /entrypoint
 
 ENV DB_DUMP_PRE_BACKUP_SCRIPTS="/scripts.d/pre-backup/"


### PR DESCRIPTION
- alpine 3.20
- golang 1.21.13
- optimize image build, 32.6MB vs. 34.4MB of the actual master tag. It's a full floppy! :)