### PR TITLE
Upgrade GitHub Actions version for CI, Release & Deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: event_name
       run: echo ${{ github.event_name }}
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
     - id: fileschanged
@@ -56,12 +56,12 @@ jobs:
     if: needs.report.outputs.non_docs_changed == 'true'
     steps:
     - name: checkout
-      uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+      uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.21'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         version: latest
     - name: Build
@@ -73,12 +73,12 @@ jobs:
     - name: Integration Test
       run: make integration_test
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         push: false
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,23 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         push: true
         platforms: linux/amd64,linux/arm64
         tags: |
           ${{env.IMAGE_NAME}}:${{github.sha}}
           ${{env.IMAGE_NAME}}:master
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,25 +21,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21
       - name: Build for all platforms
         run: |
           make build-all
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -58,7 +58,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}},value=latest
       - name: Build and push semver tag
         id: docker_build_push_semver
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Hello,

I have seen some warnings about versions into Actions logs, and then I have upgraded all versions of GitHub Actions. Unfortunately, I cannot test it on my fork, so that is the reason for the draft PR (I hope that will allow running CI workflows).

Best,

Jonathan Dreyer