### PR TITLE
remove unused TZ env var from compose example

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -47,7 +47,6 @@ services:
       AWS_SECRET_ACCESS_KEY: SUPERKEYPOWERSON
       AWS_ENDPOINT_URL: https://minio.mydomain.local
       COMPRESSION: bzip2
-      TZ: UTC
     command: dump
     depends_on:
       test-database:


### PR DESCRIPTION
The old script-based version used to support TZ for how it read cron scheduling; file timestamps and logs remain UTC. However, there is a lingering `TZ` in the compose example. This removes it.

We are open to reinstating it in the future, if someone wants to put in a PR. In that case, the docs should be updated again.