### PR TITLE
fix/mysql-backup-restore-panic

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -132,7 +132,7 @@ func restoreCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command,
 			if err := executor.Restore(ctx, restoreOpts); err != nil {
 				return fmt.Errorf("error restoring: %v", err)
 			}
-			passedExecs.GetLogger().Info("Restore complete")
+			executor.GetLogger().Info("Restore complete")
 			return nil
 		},
 	}


### PR DESCRIPTION
During the deployment of the containerized application, the Restore functionality in the mysql-backup process can result in deployment pod crashes under certain conditions. Specifically If the passedExecs instance is nil but used later to access its logger, it triggers a nil pointer dereference, causing the pod to fail.