### PR TITLE
when reporting logging messages for prune targets, correctly report the target URL

### DIFF
--- a/pkg/core/prune.go
+++ b/pkg/core/prune.go
@@ -45,7 +45,7 @@ func (e *Executor) Prune(ctx context.Context, opts PruneOptions) error {
 
 	for _, target := range opts.Targets {
 		if err := pruneTarget(tracerCtx, logger, target, now, retainHours, retainCount); err != nil {
-			return fmt.Errorf("failed to prune target %s: %v", target, err)
+			return fmt.Errorf("failed to prune target %s: %v", target.URL(), err)
 		}
 	}
 
@@ -141,7 +141,7 @@ func pruneTarget(ctx context.Context, logger *logrus.Entry, target storage.Stora
 		}
 		pruned++
 	}
-	logger.Debugf("pruning %d files from target %s", pruned, target)
+	logger.Debugf("pruning %d files from target %s", pruned, target.URL())
 	span.SetStatus(codes.Ok, fmt.Sprintf("pruned %d files", pruned))
 	return nil
 }


### PR DESCRIPTION
This was causing weird log messages, like:

```
DEBU[0000] pruning 0 files from target &{{s3  %!s(*url.Userinfo=<nil>) *********-backup-mumbai /mysql/dumps-frequent  %!s(bool=false) %!s(bool=false)   } %!s(bool=false)    }  run=7f4831e8-7247-4674-8bd2-4ccaefa848a
```