### PR TITLE
enabled TLS support with preferred config. so when server requests th…

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -26,5 +26,6 @@ func (c Connection) MySQL() string {
 		config.Addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
 	}
 	config.ParseTime = true
+	config.TLSConfig = "preferred"
 	return config.FormatDSN()
 }


### PR DESCRIPTION
…e connection is upgraded. 

This PR should not break existing connection to non TLS servers.  use of "preferred" should only upgrade connection as necessary

fixes https://github.com/databacker/mysql-backup/issues/428

fyi @deitch 