### PR TITLE
Simplify integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,5 +84,3 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: |
           ${{env.IMAGE_NAME}}:${{github.sha}}
-    - name: test
-      run: make test

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ push: build
 	docker push $(TARGET)
 
 integration_test:
-	go test -v ./test --tags=integration
+	TEST_INTEGRATION=true go test -v ./test
 
 integration_test_debug:
-	dlv --wd=./test test ./test --build-flags="-tags=integration"
+	TEST_INTEGRATION=true dlv --wd=./test test ./test
 
 vet:
 	go vet --tags=integration ./...

--- a/test/backup_log_containers.go
+++ b/test/backup_log_containers.go
@@ -1,4 +1,4 @@
-//go:build integration && !logs
+//go:build !logs
 
 package test
 

--- a/test/backup_nolog_containers.go
+++ b/test/backup_nolog_containers.go
@@ -1,4 +1,4 @@
-//go:build integration && logs
+//go:build logs
 
 package test
 

--- a/test/backup_teardown_test.go
+++ b/test/backup_teardown_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package test
 
 import "fmt"

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package test
 
 import (
@@ -931,6 +929,7 @@ log_queries_not_using_indexes = 1
 }
 
 func TestIntegration(t *testing.T) {
+	CheckSkipIntegration(t, "integration")
 	syscall.Umask(0)
 	dc, err := getDockerContext()
 	if err != nil {

--- a/test/package_noteardown_test.go
+++ b/test/package_noteardown_test.go
@@ -1,8 +1,6 @@
-//go:build integration && keepcontainers
+//go:build keepcontainers
 
 package test
-
-import "fmt"
 
 func teardown(dc *dockerContext, cids ...string) error {
 	return nil

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	integrationTestEnvVar = "TEST_INTEGRATION"
+)
+
+func IsIntegration() bool {
+	val, isIntegration := os.LookupEnv(integrationTestEnvVar)
+	return isIntegration && val != "false" && val != ""
+}
+
+func CheckSkipIntegration(t *testing.T, name string) {
+	if !IsIntegration() {
+		t.Skipf("Skipping integration test %s, set %s to run", integrationTestEnvVar, name)
+	}
+}


### PR DESCRIPTION
* remove accidental extra call of `make test` in the CI file
* simplify integration test to use env var rather than build tags, just makes it easier for IDEs to use, to see, etc.