### PR TITLE
Info message complete

### DIFF
--- a/pkg/core/dump.go
+++ b/pkg/core/dump.go
@@ -185,6 +185,8 @@ func (e *Executor) Dump(ctx context.Context, opts DumpOptions) (DumpResults, err
 	uploadSpan.SetStatus(codes.Ok, "completed")
 	uploadSpan.End()
 
+	logger.Infof("finished dump %s", now.Format(time.RFC3339))
+
 	return results, nil
 }
 


### PR DESCRIPTION
Adds two messages.

First, when a dump is complete, report an info message that dump is complete. We already have an info message for dump started, so this complements it. Debug messages already add a lot more.

Second, when a timed run is complete, log how long until the next run, also as an info message. This required a bit more work, as the timer channel needs to carry that info, but it was a simple change.