### PR TITLE
fix: ambiguity about time

### DIFF
--- a/pkg/core/timer.go
+++ b/pkg/core/timer.go
@@ -44,14 +44,14 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 	// parse the options to determine our delays
 	if opts.Cron != "" {
 		// calculate delay until next cron moment as defined
-		now := time.Now().UTC()
+		now := time.Now()
 		delay, err = waitForCron(opts.Cron, now)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cron format '%s': %v", opts.Cron, err)
 		}
 	} else if opts.Begin != "" {
 		// calculate delay based on begin time
-		now := time.Now().UTC()
+		now := time.Now()
 		delay, err = waitForBeginTime(opts.Begin, now)
 		if err != nil {
 			return nil, fmt.Errorf("invalid begin option '%s': %v", opts.Begin, err)
@@ -74,17 +74,17 @@ func Timer(opts TimerOptions) (<-chan Update, error) {
 
 		// create our delay and timer loop and go
 		for {
-			lastRun := time.Now().UTC()
+			lastRun := time.Now()
 
 			if opts.Cron != "" {
-				now := time.Now().UTC()
+				now := time.Now()
 				delay, _ = waitForCron(opts.Cron, now)
 			} else {
 				// calculate how long until the next run
 				// just take our last start time, and add the frequency until it is past our
 				// current time. We cannot just take the last time and add,
 				// because it might have been during a backup run
-				now := time.Now().UTC()
+				now := time.Now()
 				diff := int(now.Sub(lastRun).Minutes())
 				// make sure we at least wait one full frequency
 				if diff == 0 {


### PR DESCRIPTION
If the user defines the time zone of the container and uses cron at the same time, it will produce wrong results: cron.ParseStandard() defaults to using the local time zone to interpret cron expressions, but the time passed in Next is UTC, which will cause cron to change the original time zone to the time zone corresponding to the Next parameter, resulting in misunderstanding.

example:

current time: 2025-10-31T10:36:00+08:00
current timezone: +08:00

```go
package main

import (
	"fmt"
	"time"

	"github.com/robfig/cron/v3"
)

func waitForCron(cronExpr string, from time.Time) (time.Duration, error) {
	sched, err := cron.ParseStandard(cronExpr)
	if err != nil {
		return time.Duration(0), err
	}
	// sched.Next() returns the next time that the cron expression will match, beginning in 1ns;
	// we allow matching current time, so we do it from 1ns
	next := sched.Next(from.Add(-1 * time.Nanosecond))
	return next.Sub(from), nil
}

func main() {
	now := time.Now().UTC()
	d, err := waitForCron("0 3 * * *", now)
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(d)
}
```

output: 22m55.403517847s

```go
package main

import (
	"fmt"
	"time"

	"github.com/robfig/cron/v3"
)

func waitForCron(cronExpr string, from time.Time) (time.Duration, error) {
	sched, err := cron.ParseStandard(cronExpr)
	if err != nil {
		return time.Duration(0), err
	}
	// sched.Next() returns the next time that the cron expression will match, beginning in 1ns;
	// we allow matching current time, so we do it from 1ns
	next := sched.Next(from.Add(-1 * time.Nanosecond))
	return next.Sub(from), nil
}

func main() {
	now := time.Now()
	d, err := waitForCron("0 3 * * *", now)
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(d)
}
```

output: 16h22m28.330960802s

Clearly, the second one is more intuitive.