### PR TITLE
Upgrade Docker base image to Alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src/mysql-backup
 RUN mkdir /out && go build -o /out/mysql-backup .
 
 # we would do from scratch, but we need basic utilities in order to support pre/post scripts
-FROM alpine:3.20 AS runtime
+FROM alpine:3.22 AS runtime
 LABEL org.opencontainers.image.authors="https://github.com/databacker"
 
 # set us up to run as non-root user


### PR DESCRIPTION
The actual `alpine:3.20` base image will reach end of support (EOL) at 01 Apr 2026.
While `alpine:3.22` will reach EOL at 01 May 2027