### PR TITLE
Add support to TZ environment variable in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.22 AS runtime
 LABEL org.opencontainers.image.authors="https://github.com/databacker"
 
 # set us up to run as non-root user
-RUN apk add --no-cache bash && \
+RUN apk add --no-cache bash tzdata && \
     addgroup -g 1005 appuser && \
     adduser -u 1005 -G appuser -D appuser
 


### PR DESCRIPTION
Installing `tzdata` package in Docker image allow us to set `TZ` environment variable.
This PR close this issues:
- https://github.com/databacker/mysql-backup/issues/374
- https://github.com/databacker/mysql-backup/issues/203
- https://github.com/databacker/mysql-backup/issues/135