### PR TITLE
include routines and stored procedures by default

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -122,11 +122,12 @@ func dumpCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command, er
 			if !v.IsSet("compact") && dumpConfig != nil && dumpConfig.Compact != nil {
 				compact = *dumpConfig.Compact
 			}
-			// should we dump triggers and functions and procedures?
+			// should we dump triggers?
 			triggers := v.GetBool("triggers")
 			if !v.IsSet("triggers") && dumpConfig != nil && dumpConfig.Triggers != nil {
 				triggers = *dumpConfig.Triggers
 			}
+			// should we dump stored procedures and routines?
 			routines := v.GetBool("routines")
 			if !v.IsSet("routines") && dumpConfig != nil && dumpConfig.Routines != nil {
 				routines = *dumpConfig.Routines
@@ -348,8 +349,11 @@ S3: If it is a URL of the format s3://bucketname/path then it will connect via S
 	// max-allowed-packet size
 	flags.Int("max-allowed-packet", defaultMaxAllowedPacket, "Maximum size of the buffer for client/server communication, similar to mysqldump's max_allowed_packet. 0 means to use the default size.")
 
-	// whether to include triggers and functions
-	flags.Bool("triggers-and-functions", false, "Whether to include triggers and functions in the dump.")
+	// whether to include triggers
+	flags.Bool("triggers", false, "Whether to include triggers in the dump.")
+
+	// stored procedures and routines
+	flags.Bool("routines", true, "Whether to include stored procedures and routines in the dump.")
 
 	cmd.MarkFlagsMutuallyExclusive("once", "cron")
 	cmd.MarkFlagsMutuallyExclusive("once", "begin")

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -39,6 +39,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"file URL with pass-file", []string{"--server", "abc", "--target", "file:///foo/bar", "--pass-file", "testdata/password.txt"}, "", false, core.DumpOptions{
@@ -47,6 +48,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort, Pass: "testpassword"},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"file URL with pass and pass-file (pass takes precedence)", []string{"--server", "abc", "--target", "file:///foo/bar", "--pass", "explicitpass", "--pass-file", "testdata/password.txt"}, "", false, core.DumpOptions{
@@ -55,6 +57,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort, Pass: "explicitpass"},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"file URL with prune", []string{"--server", "abc", "--target", "file:///foo/bar", "--retention", "1h"}, "", false, core.DumpOptions{
@@ -63,6 +66,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
 
@@ -73,6 +77,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"database explicit name with explicit port", []string{"--server", "abc", "--port", "3307", "--target", "file:///foo/bar"}, "", false, core.DumpOptions{
@@ -81,6 +86,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: 3307},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 
@@ -91,6 +97,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abcd", Port: 3306, User: "user2", Pass: "xxxx2"},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
 		{"config file with port override", []string{"--config-file", "testdata/config.yml", "--port", "3307"}, "", false, core.DumpOptions{
@@ -99,6 +106,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abcd", Port: 3307, User: "user2", Pass: "xxxx2"},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
 		{"config file with filename pattern override", []string{"--config-file", "testdata/pattern.yml", "--port", "3307"}, "", false, core.DumpOptions{
@@ -107,6 +115,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abcd", Port: 3307, User: "user2", Pass: "xxxx2"},
 			FilenamePattern:  "foo_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, &core.PruneOptions{Targets: []storage.Storage{file.New(*fileTargetURL)}, Retention: "1h"}},
 
@@ -117,6 +126,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Once: true, Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"cron flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--cron", "0 0 * * *"}, "", false, core.DumpOptions{
@@ -125,6 +135,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin, Cron: "0 0 * * *"}, nil},
 		{"begin flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--begin", "1234"}, "", false, core.DumpOptions{
@@ -133,6 +144,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: "1234"}, nil},
 		{"frequency flag", []string{"--server", "abc", "--target", "file:///foo/bar", "--frequency", "10"}, "", false, core.DumpOptions{
@@ -141,6 +153,7 @@ func TestDumpCmd(t *testing.T) {
 			Compressor:       &compression.GzipCompressor{},
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: 10, Begin: defaultBegin}, nil},
 		{"incompatible flags: once/cron", []string{"--server", "abc", "--target", "file:///foo/bar", "--once", "--cron", "0 0 * * *"}, "", true, core.DumpOptions{}, core.TimerOptions{}, nil},
@@ -159,6 +172,7 @@ func TestDumpCmd(t *testing.T) {
 			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
 			PreBackupScripts: "/prebackup",
 			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
 			Parallelism:      1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"postbackup scripts", []string{"--server", "abc", "--target", "file:///foo/bar", "--post-backup-scripts", "/postbackup"}, "", false, core.DumpOptions{
@@ -168,6 +182,7 @@ func TestDumpCmd(t *testing.T) {
 			DBConn:            &database.Connection{Host: "abc", Port: defaultPort},
 			PostBackupScripts: "/postbackup",
 			FilenamePattern:   "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:          true,
 			Parallelism:       1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 		{"prebackup and postbackup scripts", []string{"--server", "abc", "--target", "file:///foo/bar", "--post-backup-scripts", "/postbackup", "--pre-backup-scripts", "/prebackup"}, "", false, core.DumpOptions{
@@ -178,6 +193,7 @@ func TestDumpCmd(t *testing.T) {
 			PreBackupScripts:  "/prebackup",
 			PostBackupScripts: "/postbackup",
 			FilenamePattern:   "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:          true,
 			Parallelism:       1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,8 @@ The following are the environment variables, CLI flags and configuration file op
 | SMB username, used only if a target does not have one | BRP | `smb-user` | `SMB_USER` | `dump.targets[smb-target].username` |  |
 | SMB password, used only if a target does not have one | BRP | `smb-pass` | `SMB_PASS` | `dump.targets[smb-target].password` |  |
 | compression to use, one of: `bzip2`, `gzip`, `none` | BP | `compression` | `DB_DUMP_COMPRESSION` | `dump.compression` | `gzip` |
-| whether to include triggers, procedures and functions | B | `triggers-and-functions` | `DB_DUMP_TRIGGERS_AND_FUNCTIONS` | `dump.triggersAndFunctions` | `false` |
+| whether to include triggers | B | `triggers` | `DB_DUMP_TRIGGERS` | `dump.triggers` | `false` |
+| whether to include stored procedures and routines | B | `routines` | `DB_DUMP_ROUTINES` | `dump.routines` | `true` |
 | when in container, run the dump or restore with `nice`/`ionice` | BR | `` | `NICE` | `` | `false` |
 | filename to save the target backup file | B | `dump --filename-pattern` | `DB_DUMP_FILENAME_PATTERN` | `dump.filenamePattern` |  |
 | directory with scripts to execute before backup | B | `dump --pre-backup-scripts` | `DB_DUMP_PRE_BACKUP_SCRIPTS` | `dump.scripts.preBackup` | in container, `/scripts.d/pre-backup/` |


### PR DESCRIPTION
Also cleans up the naming of flags between routines (stored procedures, routines) and triggers