### PR TITLE
fix: `packet for query is too large` error in restore

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -24,7 +24,7 @@ const (
 	defaultCompression      = "gzip"
 	defaultBegin            = "+0"
 	defaultFrequency        = 1440
-	defaultMaxAllowedPacket = 4194304
+	defaultMaxAllowedPacket = 4 << 20 // 4 MiB (4194304)
 	defaultFilenamePattern  = core.DefaultFilenamePattern
 )
 
@@ -135,6 +135,9 @@ func dumpCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command, er
 			maxAllowedPacket := v.GetInt("max-allowed-packet")
 			if !v.IsSet("max-allowed-packet") && dumpConfig != nil && dumpConfig.MaxAllowedPacket != nil && *dumpConfig.MaxAllowedPacket != 0 {
 				maxAllowedPacket = *dumpConfig.MaxAllowedPacket
+			}
+			if maxAllowedPacket != 0 && maxAllowedPacket != defaultMaxAllowedPacket {
+				cmdConfig.dbconn.MaxAllowedPacket = maxAllowedPacket
 			}
 
 			// compression algorithm: check config, then CLI/env var overrides

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -75,6 +75,12 @@ func restoreCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command,
 				}
 			}
 
+			// max-allowed-packet size
+			maxAllowedPacket := v.GetInt("max-allowed-packet")
+			if maxAllowedPacket != 0 && maxAllowedPacket != defaultMaxAllowedPacket {
+				cmdConfig.dbconn.MaxAllowedPacket = maxAllowedPacket
+			}
+
 			// target URL can reference one from the config file, or an absolute one
 			// if it's not in the config file, it's an absolute one
 			// if it is in the config file, it's a reference to one of the targets in the config file
@@ -159,6 +165,9 @@ func restoreCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command,
 
 	// post-restore scripts
 	flags.String("post-restore-scripts", "", "Directory wherein any file ending in `.sh` will be run post-restore.")
+
+	// max-allowed-packet size
+	flags.Int("max-allowed-packet", 0, "Maximum size of the buffer for client/server communication, similar to mysql's max_allowed_packet. 0 means to use the default size.")
 
 	return cmd, nil
 }

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Connection struct {
-	User            string
-	Pass            string
-	Host            string
-	Port            int
-	MultiStatements bool
+	User             string
+	Pass             string
+	Host             string
+	Port             int
+	MultiStatements  bool
+	MaxAllowedPacket int
 
 	// holds a connection to the database
 	sql *sql.DB
@@ -36,6 +37,9 @@ func (c *Connection) MySQL() (*sql.DB, error) {
 		config.ParseTime = true
 		config.TLSConfig = "preferred"
 		config.MultiStatements = c.MultiStatements
+		if c.MaxAllowedPacket != 0 {
+			config.MaxAllowedPacket = c.MaxAllowedPacket
+		}
 		dsn := config.FormatDSN()
 		handle, err := sql.Open("mysql", dsn)
 		if err != nil {


### PR DESCRIPTION
environment:

```
root@9db45bba0a23:/# mariadb -uroot -p"${MARIADB_ROOT_PASSWORD}" --execute "SHOW VARIABLES LIKE 'max_allowed_packet';"
+--------------------+------------+
| Variable_name      | Value      |
+--------------------+------------+
| max_allowed_packet | 1073741824 |
+--------------------+------------+
```

```
mariadb --max-allowed-packet=1G -uroot -p"${MARIADB_ROOT_PASSWORD}" < data_2026-02-26T10\:19\:47+08\:00.sql
```
successful

but

```
./mysql-backup restore --server 127.0.0.1 --port 3307 --user root --pass 'password' --target "$(pwd)" db_backup.tgz
INFO[0000] beginning restore                             run=2e25518b-1aef-4aa8-846d-115ee757194d
Error: error restoring: failed to restore database: failed to restore database: packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`
FATA[0388] error restoring: failed to restore database: failed to restore database: packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`
```

after change

```
./mysql-backup restore --max-allowed-packet 1073741824 --server 127.0.0.1 --port 3307 --user root --pass 'password' --target "$(pwd)" db_backup.tgz
INFO[0000] beginning restore                             run=a803e093-77ce-49eb-9295-d5af606d2957
INFO[0486] Restore complete
```