### PR TITLE
feat: add --ignore-tables flag and fix broken DB_DUMP_EXCLUDE

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -133,6 +133,11 @@ func dumpCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command, er
 			if !v.IsSet("routines") && dumpConfig != nil && dumpConfig.Routines != nil {
 				routines = *dumpConfig.Routines
 			}
+			ignoreTables := v.GetStringSlice("ignore-tables")
+			if len(ignoreTables) == 0 {
+				ignoreTables = nil
+			}
+
 			maxAllowedPacket := v.GetInt("max-allowed-packet")
 			if !v.IsSet("max-allowed-packet") && dumpConfig != nil && dumpConfig.MaxAllowedPacket != nil && *dumpConfig.MaxAllowedPacket != 0 {
 				maxAllowedPacket = *dumpConfig.MaxAllowedPacket
@@ -305,6 +310,7 @@ func dumpCmd(passedExecs execs, cmdConfig *cmdConfiguration) (*cobra.Command, er
 					Run:                 uid,
 					FilenamePattern:     filenamePattern,
 					Parallelism:         parallel,
+					IgnoreTables:        ignoreTables,
 				}
 				results, err := executor.Dump(tracerCtx, dumpOpts)
 				if err != nil {
@@ -402,6 +408,9 @@ S3: If it is a URL of the format s3://bucketname/path then it will connect via S
 	cmd.MarkFlagsMutuallyExclusive("cron", "frequency")
 	// retention
 	flags.String("retention", "", "Retention period for backups. Optional. If not specified, no pruning will be done. Can be number of backups or time-based. For time-based, the format is: 1d, 1w, 1m, 1y for days, weeks, months, years, respectively. For number-based, the format is: 1c, 2c, 3c, etc. for the count of backups to keep.")
+
+	// ignore-tables: tables to exclude from the dump (format: database.table)
+	flags.StringSlice("ignore-tables", []string{}, "Tables to exclude from the dump. Format: database.table (e.g. mydb.mytable). Can be specified multiple times or as a comma-separated list.")
 
 	// encryption options
 	flags.String("encryption", "", fmt.Sprintf("Encryption algorithm to use, none if blank. Supported are: %s. Format must match the specific algorithm.", strings.Join(encrypt.All, ", ")))

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -409,8 +409,8 @@ S3: If it is a URL of the format s3://bucketname/path then it will connect via S
 	// retention
 	flags.String("retention", "", "Retention period for backups. Optional. If not specified, no pruning will be done. Can be number of backups or time-based. For time-based, the format is: 1d, 1w, 1m, 1y for days, weeks, months, years, respectively. For number-based, the format is: 1c, 2c, 3c, etc. for the count of backups to keep.")
 
-	// ignore-tables: tables to exclude from the dump (format: database.table)
-	flags.StringSlice("ignore-tables", []string{}, "Tables to exclude from the dump. Format: database.table (e.g. mydb.mytable). Can be specified multiple times or as a comma-separated list.")
+	// ignore-tables: tables to exclude from the dump (formats: database.table or table)
+	flags.StringSlice("ignore-tables", []string{}, "Tables to exclude from the dump. Formats: database.table (e.g. mydb.mytable) or table (applies to all databases/schemas). Can be specified multiple times or as a comma-separated list.")
 
 	// encryption options
 	flags.String("encryption", "", fmt.Sprintf("Encryption algorithm to use, none if blank. Supported are: %s. Format must match the specific algorithm.", strings.Join(encrypt.All, ", ")))

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -196,6 +196,38 @@ func TestDumpCmd(t *testing.T) {
 			Routines:          true,
 			Parallelism:       1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+
+		// ignore-tables
+		{"ignore-tables single", []string{"--server", "abc", "--target", "file:///foo/bar", "--ignore-tables", "mydb.mytable"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			IgnoreTables:     []string{"mydb.mytable"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+		{"ignore-tables comma-separated", []string{"--server", "abc", "--target", "file:///foo/bar", "--ignore-tables", "db1.table1,db2.table2"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			IgnoreTables:     []string{"db1.table1", "db2.table2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+		{"ignore-tables multiple flags", []string{"--server", "abc", "--target", "file:///foo/bar", "--ignore-tables", "db1.table1", "--ignore-tables", "db2.table2"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			IgnoreTables:     []string{"db1.table1", "db2.table2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 	}
 
 	for _, tt := range tests {

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -197,6 +197,38 @@ func TestDumpCmd(t *testing.T) {
 			Parallelism:       1,
 		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
 
+		// exclude
+		{"exclude single", []string{"--server", "abc", "--target", "file:///foo/bar", "--exclude", "mydb"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			Exclude:          []string{"mydb"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+		{"exclude comma-separated", []string{"--server", "abc", "--target", "file:///foo/bar", "--exclude", "db1,db2"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			Exclude:          []string{"db1", "db2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+		{"exclude multiple flags", []string{"--server", "abc", "--target", "file:///foo/bar", "--exclude", "db1", "--exclude", "db2"}, "", false, core.DumpOptions{
+			Targets:          []storage.Storage{file.New(*fileTargetURL)},
+			MaxAllowedPacket: defaultMaxAllowedPacket,
+			Compressor:       &compression.GzipCompressor{},
+			DBConn:           &database.Connection{Host: "abc", Port: defaultPort},
+			FilenamePattern:  "db_backup_{{ .now }}.{{ .compression }}",
+			Routines:         true,
+			Parallelism:      1,
+			Exclude:          []string{"db1", "db2"},
+		}, core.TimerOptions{Frequency: defaultFrequency, Begin: defaultBegin}, nil},
+
 		// ignore-tables
 		{"ignore-tables single", []string{"--server", "abc", "--target", "file:///foo/bar", "--ignore-tables", "mydb.mytable"}, "", false, core.DumpOptions{
 			Targets:          []storage.Storage{file.New(*fileTargetURL)},

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -14,7 +14,7 @@ to a target. That target can be one of:
 
 By default, all databases in the database server are backed up, and the system databases
 named `information_schema`, `performance_schema`, `sys` and `mysql` are excluded.
-For example, if you set `DB_DUMP_EXCLUDE=database1 db2` then these two databases will not be dumped.
+For example, if you set `DB_DUMP_EXCLUDE=database1,db2` then these two databases will not be dumped.
 
 **Dumping just some databases**
 

--- a/pkg/core/dump.go
+++ b/pkg/core/dump.go
@@ -93,6 +93,8 @@ func (e *Executor) Dump(ctx context.Context, opts DumpOptions) (DumpResults, err
 			return results, fmt.Errorf("failed to list database schemas: %v", err)
 		}
 	}
+	// filter out excluded databases
+	dbnames = filterExcludedDatabases(dbnames, opts.Exclude)
 	span.SetAttributes(attribute.StringSlice("actual-schemas", dbnames))
 	for _, s := range dbnames {
 		outFile := path.Join(workdir, fmt.Sprintf("%s_%s.sql", s, timepart))
@@ -257,4 +259,22 @@ func ProcessFilenamePattern(pattern string, now time.Time, timestamp, ext string
 		return "", fmt.Errorf("failed to execute filename pattern: %v", err)
 	}
 	return buf.String(), nil
+}
+
+// filterExcludedDatabases removes databases in the exclude list from dbnames.
+func filterExcludedDatabases(dbnames, exclude []string) []string {
+	if len(exclude) == 0 {
+		return dbnames
+	}
+	excludeMap := make(map[string]bool, len(exclude))
+	for _, e := range exclude {
+		excludeMap[e] = true
+	}
+	filtered := make([]string, 0, len(dbnames))
+	for _, db := range dbnames {
+		if !excludeMap[db] {
+			filtered = append(filtered, db)
+		}
+	}
+	return filtered
 }

--- a/pkg/core/dump.go
+++ b/pkg/core/dump.go
@@ -116,6 +116,7 @@ func (e *Executor) Dump(ctx context.Context, opts DumpOptions) (DumpResults, err
 		MaxAllowedPacket:    maxAllowedPacket,
 		PostDumpDelay:       opts.PostDumpDelay,
 		Parallelism:         parallelism,
+		IgnoreTables:        opts.IgnoreTables,
 	}, dw); err != nil {
 		dbDumpSpan.SetStatus(codes.Error, err.Error())
 		dbDumpSpan.End()

--- a/pkg/core/dump_test.go
+++ b/pkg/core/dump_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestFilterExcludedDatabases(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbnames  []string
+		exclude  []string
+		expected []string
+	}{
+		{
+			name:     "no exclusions",
+			dbnames:  []string{"db1", "db2", "db3"},
+			exclude:  nil,
+			expected: []string{"db1", "db2", "db3"},
+		},
+		{
+			name:     "empty exclusions",
+			dbnames:  []string{"db1", "db2", "db3"},
+			exclude:  []string{},
+			expected: []string{"db1", "db2", "db3"},
+		},
+		{
+			name:     "exclude one",
+			dbnames:  []string{"db1", "db2", "db3"},
+			exclude:  []string{"db2"},
+			expected: []string{"db1", "db3"},
+		},
+		{
+			name:     "exclude multiple",
+			dbnames:  []string{"db1", "db2", "db3", "db4"},
+			exclude:  []string{"db2", "db4"},
+			expected: []string{"db1", "db3"},
+		},
+		{
+			name:     "exclude all",
+			dbnames:  []string{"db1", "db2"},
+			exclude:  []string{"db1", "db2"},
+			expected: []string{},
+		},
+		{
+			name:     "exclude nonexistent",
+			dbnames:  []string{"db1", "db2"},
+			exclude:  []string{"db99"},
+			expected: []string{"db1", "db2"},
+		},
+		{
+			name:     "exclude with mixed existing and nonexistent",
+			dbnames:  []string{"db1", "db2", "db3"},
+			exclude:  []string{"db2", "db99"},
+			expected: []string{"db1", "db3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterExcludedDatabases(tt.dbnames, tt.exclude)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Fatalf("expected %v, got %v", tt.expected, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/dumpoptions.go
+++ b/pkg/core/dumpoptions.go
@@ -31,5 +31,6 @@ type DumpOptions struct {
 	// PostDumpDelay inafter each dump is complete, while holding connection open. Do not use outside of tests.
 	PostDumpDelay time.Duration
 	// Parallelism how many databases to back up at once, consuming that number of threads
-	Parallelism int
+	Parallelism  int
+	IgnoreTables []string
 }

--- a/pkg/database/dump.go
+++ b/pkg/database/dump.go
@@ -19,6 +19,7 @@ type DumpOpts struct {
 	// PostDumpDelay after each dump is complete, while holding connection open. Do not use outside of tests.
 	PostDumpDelay time.Duration
 	Parallelism   int
+	IgnoreTables  []string
 }
 
 func Dump(ctx context.Context, dbconn *Connection, opts DumpOpts, writers []DumpWriter) error {
@@ -63,6 +64,7 @@ func Dump(ctx context.Context, dbconn *Connection, opts DumpOpts, writers []Dump
 					SkipExtendedInsert:  opts.SkipExtendedInsert,
 					MaxAllowedPacket:    opts.MaxAllowedPacket,
 					PostDumpDelay:       opts.PostDumpDelay,
+					IgnoreTables:        opts.IgnoreTables,
 				}
 				// return on any error
 				if err := dumper.Dump(); err != nil {

--- a/pkg/database/mysql/dump.go
+++ b/pkg/database/mysql/dump.go
@@ -400,7 +400,12 @@ func (data *Data) getCharsetCollections() error {
 
 func (data *Data) isIgnoredTable(name string) bool {
 	for _, item := range data.IgnoreTables {
-		if item == name {
+		if strings.Contains(item, ".") {
+			parts := strings.SplitN(item, ".", 2)
+			if parts[0] == data.Schema && parts[1] == name {
+				return true
+			}
+		} else if item == name {
 			return true
 		}
 	}

--- a/pkg/database/mysql/dump_test.go
+++ b/pkg/database/mysql/dump_test.go
@@ -1,0 +1,38 @@
+package mysql
+
+import "testing"
+
+func TestIsIgnoredTable(t *testing.T) {
+	tests := []struct {
+		name         string
+		schema       string
+		ignoreTables []string
+		tableName    string
+		expected     bool
+	}{
+		{"exact table name match", "mydb", []string{"mytable"}, "mytable", true},
+		{"table name no match", "mydb", []string{"othertable"}, "mytable", false},
+		{"qualified match same schema", "backuppc", []string{"backuppc.hosts"}, "hosts", true},
+		{"qualified match wrong schema", "otherdb", []string{"backuppc.hosts"}, "hosts", false},
+		{"qualified match wrong table", "backuppc", []string{"backuppc.hosts"}, "summary", false},
+		{"multiple entries with qualified match", "backuppc", []string{"otherdb.foo", "backuppc.hosts"}, "hosts", true},
+		{"multiple entries no match", "backuppc", []string{"otherdb.foo", "otherdb.bar"}, "hosts", false},
+		{"mixed qualified and unqualified", "mydb", []string{"backuppc.hosts", "globaltable"}, "globaltable", true},
+		{"empty ignore list", "mydb", []string{}, "mytable", false},
+		{"nil ignore list", "mydb", nil, "mytable", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := &Data{
+				Schema:       tt.schema,
+				IgnoreTables: tt.ignoreTables,
+			}
+			got := data.isIgnoredTable(tt.tableName)
+			if got != tt.expected {
+				t.Errorf("isIgnoredTable(%q) = %v, want %v (schema=%q, ignoreTables=%v)",
+					tt.tableName, got, tt.expected, tt.schema, tt.ignoreTables)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

### New feature: `--ignore-tables`
- Wires up the existing but unused `IgnoreTables` support in `pkg/database/mysql/dump.go` to the CLI and environment variables
- Adds `--ignore-tables` CLI flag (auto-binds to `DB_DUMP_IGNORE_TABLES` env var via viper)
- Threads `IgnoreTables []string` through all intermediate layers (`DumpOpts` → `DumpOptions` → `database.DumpOpts` → `mysql.Data`)
- Fixes `isIgnoredTable()` to support qualified `database.table` format (e.g. `mydb.mytable`) in addition to bare table names

### Bug fix: `DB_DUMP_EXCLUDE` / `--exclude` was completely broken
- The `Exclude` field in `DumpOptions` was populated from CLI/env vars but **never read** in the `Dump()` function (`pkg/core/dump.go`)
- All databases were dumped regardless of the exclude list — the field was dead code
- Extracted `filterExcludedDatabases()` function and applied it after schema discovery
- Fixed documentation typo (space-separated → comma-separated format)

## Motivation

**--ignore-tables:** The old shell-based image supported `MYSQLDUMP_OPTS="--ignore-table=db.table"`, but this was lost in the Go rewrite (v1.0+). The underlying `mysql.Data.IgnoreTables` field and `isIgnoredTable()` method already existed but were never connected to any user-facing configuration. This was reported in #309.

**DB_DUMP_EXCLUDE:** The exclude feature was documented and accepted via CLI/env vars, but the filtering logic was never implemented in `pkg/core/dump.go`. The `opts.Exclude` field was set but never read, causing disk-full incidents in production.

## Usage

### Exclude databases
```bash
# CLI flag
dump --exclude=tempdb,archivedb

# Environment variable
DB_DUMP_EXCLUDE=tempdb,archivedb
```

### Ignore tables
```bash
# CLI flag
dump --ignore-tables=mydb.mytable,otherdb.bigtable

# or multiple flags
dump --ignore-tables=mydb.mytable --ignore-tables=otherdb.bigtable

# Environment variable (e.g. docker-compose)
DB_DUMP_IGNORE_TABLES=mydb.mytable,otherdb.bigtable
```

Both qualified (`database.table`) and unqualified (`table`) formats are supported:
- `backuppc.hosts` — ignores `hosts` only in the `backuppc` database
- `hosts` — ignores `hosts` in all databases

## Test plan

- [x] Added 3 test cases to `cmd/dump_test.go` for `--exclude`: single, comma-separated, multiple flags
- [x] Added 7 test cases in `pkg/core/dump_test.go` for `filterExcludedDatabases()`
- [x] Added 3 test cases to `cmd/dump_test.go` for `--ignore-tables`
- [x] Added 10 test cases in `pkg/database/mysql/dump_test.go` for `isIgnoredTable()`
- [x] All existing tests pass
- [x] Verified with real MySQL: DB_DUMP_EXCLUDE now correctly excludes databases from the dump

Closes #309